### PR TITLE
RevealJS has several data-* modifiers on a section

### DIFF
--- a/haml/revealjs/section.html.haml
+++ b/haml/revealjs/section.html.haml
@@ -1,5 +1,10 @@
 
-%section{:id=>id, :'data-transition'=>(attr 'data-transition'), :'data-transition-speed'=>(attr 'data-transition-speed'), :'data-background'=>(attr 'data-background'), :'data-background-size'=>(attr 'data-background-size'), :'data-background-repeat'=>(attr 'data-background-repeat') }
+%section{:id=>id, :'data-transition'=>(attr 'data-transition'), 
+:'data-transition-speed'=>(attr 'data-transition-speed'), 
+:'data-background'=>(attr 'data-background'), 
+:'data-background-size'=>(attr 'data-background-size'), 
+:'data-background-repeat'=>(attr 'data-background-repeat'), 
+:'data-background-transition'=>(attr 'data-background-transition') }
   %h2=title
   =content.chomp
 


### PR DESCRIPTION
Added the data-\* items on section level for RevealJS backend.
We now can change the background color/image and transformations.
