### PR TITLE
allow step to be option or role in revealjs

### DIFF
--- a/haml/revealjs/block_olist.html.haml
+++ b/haml/revealjs/block_olist.html.haml
@@ -1,6 +1,6 @@
 %ol{:class=>(attr :style), :start=>(attr :start)}
   - content.each do |item|
-    %li{:class=>('fragment' if attr? 'step-option')}
+    %li{:class=>('fragment' if (option? 'step') or (has_role? 'step')}
       - if item.blocks?
         %p=item.text
         =item.content.chomp

--- a/haml/revealjs/block_ulist.html.haml
+++ b/haml/revealjs/block_ulist.html.haml
@@ -1,6 +1,6 @@
 %ul
   - content.each do |item|
-    %li{:class=>('fragment' if attr? 'step-option')}
+    %li{:class=>('fragment' if (option? 'step') or (has_role? 'step')}
       - if item.blocks?
         %p=item.text
         =item.content.chomp


### PR DESCRIPTION
Here's what I mean about allowing the step to be either an option or a role.

Both of these would work:

```
[.step]
* one
* two
* three
```

or

```
[%step]
* one
* two
* three
```
