### PR TITLE
Add attribute :menu and syntax required by deck.js

### DIFF
--- a/haml/deckjs/document.html.haml
+++ b/haml/deckjs/document.html.haml
@@ -89,7 +89,6 @@
     %script(src='deck.js/extensions/menu/deck.menu.js')
     %script(src='deck.js/extensions/navigation/deck.navigation.js')
     %script(src='deck.js/extensions/scale/deck.scale.js')
-    %script(src='deck.js/extensions/split/deck.split.js')
     %script(src='deck.js/extensions/status/deck.status.js')
     %script(src='deck.js/extensions/toc/deck.toc.js')
     - if attr? :menu


### PR DESCRIPTION
The attribute :menu does not exist within the document.html.haml page aven if we have in this page the css and javascript
