### PR TITLE
Add missing audio block for Deckjs backend / HAML

### DIFF
--- a/haml/deckjs/block_audio.html.haml
+++ b/haml/deckjs/block_audio.html.haml
@@ -1,0 +1,7 @@
+%div{:id=>@id, :class=>['audioblock', @style, role]}
+  - if title?
+    .title=captioned_title
+  .content
+    %audio{:src=>media_uri(attr :target), :autoplay=>(option? :autoplay),
+        :controls=>!(option? :nocontrols), :loop=>(option? :loop)}
+      Your browser does not support the audio tag.


### PR DESCRIPTION
Fix problem explained here : https://github.com/asciidoctor/asciidoctor-backends/issues/32
