### PR TITLE
add a README for the dzslides backend

### DIFF
--- a/slim/dzslides/README.adoc
+++ b/slim/dzslides/README.adoc
@@ -1,0 +1,79 @@
+= Dzslides backend
+
+=== Installation
+
+First, you should download (or git clone) the https://github.com/asciidoctor/asciidoctor-backends[asciidoctor-backends] repository to a convenient location.
+
+ git clone git://github.com/asciidoctor/asciidoctor-backends.git
+
+Then from your working directory (that is where your AsciiDoc document resides) you must clone the https://github.com/mojavelinux/asciidoc-dzslides-backend.git[dzslides] repository into a +dzslides+ directory.
+
+ git clone https://github.com/mojavelinux/asciidoc-dzslides-backend.git dzslides
+
+=== Settings
+
+There are some attributes that can be set at the top of the document which they are specific of +dzslides+ backend.
+
+[options="header",cols="1m,1"]
+|===
+|Attribute                          |Description
+|:dzslides-style: <style>           |where you set the dzslides style. For example : watermelon
+|:dzslides-transition: <transition> |where you set the kind of transition. For example : fade
+|:dzslides-fonts: <font>            |where you set the fonts. For example: family=Cedarville+Cursive
+|:dzslides-highlight: <highlight>   |where you set the highlight. For example: monokai
+|===
+
+NOTE: You can also specify a custom stylesheet using the +stylesheet+ attribute, which can be used to customize AsciiDoc elements like section, paragraph, images, etc...
+
+=== Examples
+
+----
+Dzslides
+========
+:backend: dzslides
+:dzslides-style: watermelon
+:dzslides-transition: fade
+:dzslides-fonts: family=Yanone+Kaffeesatz:400,700,200,300&family=Cedarville+Cursive
+:dzslides-highlight: monokai
+:stepwise: role="incremental"
+
+[{intro}]
+== Intro
+
+== \\
+
+*Title*
+
+== \\
+
+[{stepwise}]
+* dzslides
+* deckjs
+----
+
+You can see some more complete examples https://github.com/mojavelinux/dzslides[here].
+
+
+=== Rendering
+
+First, make sure Asciidoctor is installed:
+
+ gem install asciidoctor
+
+You might also need tilt and slim:
+
+ gem install tilt
+ gem install slim
+
+Then, to render your presentation as HTML5, simply execute the command:
+
+ asciidoctor -T <backend directory> <asciidoc file>
+ 
+So for the above dzslides backend you'd use
+ 
+ asciidoctor -T <base>/asciidoctor-backends/slim/dzslides <asciidoc file> 
+
+=== Stay Connected
+
+If you need any other feature supported by +dzslides+ to be ported to this backend, any way to make it better or you find any bug do not hesitate to open an issue. 
+


### PR DESCRIPTION
This is a rough attempt to add some documentation for the dzslides backend (heavily inspired from the deckjs one).

My knowledge is quite limited on this subject, but I managed to make it work based on the deckjs example and what I had with Asciidoc, with no major regressions on one of my slidedeck (which is now rendering 15x faster thx to asciidoctor!)

That should be a beginning for issue #5. What do you think? 
