### PR TITLE
Added 'revealjs_customtheme' attribute to specify custom theme files

### DIFF
--- a/slim/revealjs/document.html.slim
+++ b/slim/revealjs/document.html.slim
@@ -15,6 +15,8 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
 
     - if attr? :revealjs_theme
       link rel='stylesheet' href='revealjs/css/theme/#{attr :revealjs_theme}.css' id='theme'
+    - elsif attr? :revealjs_customtheme
+      link rel='stylesheet' href='#{attr :revealjs_customtheme}' id='theme'
     - else
       link rel='stylesheet' href='revealjs/css/theme/default.css' id='default_theme'
 


### PR DESCRIPTION
With the new attribute "revealjs_customtheme" one can create a custom CSS theme for reveal.js which doesn't need to be located in the "revealjs/css/theme" folder. I need this to support an enhancement for https://github.com/ysb33r/SampleProjects/tree/master/revealJS
