### PR TITLE
fixed link to print stylesheets

### DIFF
--- a/slim/revealjs/document.html.slim
+++ b/slim/revealjs/document.html.slim
@@ -24,7 +24,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
     link href="revealjs/lib/css/zenburn.css" rel="stylesheet"
     // If the query includes 'print-pdf', use the PDF print sheet
     javascript:
-      document.write( '<link rel="stylesheet" href="css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
+      document.write( '<link rel="stylesheet" href="revealjs/css/print/' + ( window.location.search.match( /print-pdf/gi ) ? 'pdf' : 'paper' ) + '.css" type="text/css" media="print">' );
   body
     .reveal
       // Any section element inside of this container is displayed as a slide
@@ -42,7 +42,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
          // Display a presentation progress bar
          progress: true,
          // Push each slide change to the browser history
-         history: false,
+         history: true,
          // Enable keyboard shortcuts for navigation
          keyboard: true,
          // Enable the slide overview mode


### PR DESCRIPTION
link to the print stylesheet was broken. 

I additionally enabled the "history" option. Any reason this was disabled?
