### PR TITLE
revealjs: mention that the default settings come from revealjs project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -146,6 +146,11 @@ the [reveal.js] repository.
 There are some attributes that can be set at the top of the document which
 they are specific of +revealjs+ backend.
 
+[NOTE]
+--
+Default settings are based on `reveal.js` default settings.
+--
+
 [options="header",cols="1m,1"]
 |===
 |Attribute                            |Description


### PR DESCRIPTION
Addressing comment: https://github.com/asciidoctor/asciidoctor-backends/pull/54#discussion_r18015593

Also, did you want me to specifically address the history setting? I'm afraid that injection a [NOTE] in the table will make things ugly (both in the plaintext and github rendered version).
