### PR TITLE
Fix typo in html5/block_preamble.{haml,slim}

### DIFF
--- a/haml/html5/block_preamble.html.haml
+++ b/haml/html5/block_preamble.html.haml
@@ -4,4 +4,4 @@
   - if (attr? :toc) && (attr? 'toc-placement', 'preamble')
     #toc{:class=>(attr 'toc-class', 'toc')}
       #toctitle=(attr 'toc-title')
-      =converters.convert @document, 'outline'
+      =converter.convert @document, 'outline'

--- a/slim/html5/block_preamble.html.slim
+++ b/slim/html5/block_preamble.html.slim
@@ -3,4 +3,4 @@
   - if (attr? :toc) && (attr? 'toc-placement', 'preamble')
     #toc class=(attr 'toc-class', 'toc')
       #toctitle=(attr 'toc-title')
-      =converters.convert @document, 'outline'
+      =converter.convert @document, 'outline'


### PR DESCRIPTION
Variable `converters` doesn't exist, it should be `converter`.
