### PR TITLE
Fix slim/html5 templates to not render empty style tag

### DIFF
--- a/slim/html5/block_image.html.slim
+++ b/slim/html5/block_image.html.slim
@@ -1,5 +1,4 @@
-.imageblock(id=@id class=[@style,role]
-    style=[("text-align: #{attr :align}" if attr? :align),("float: #{attr :float}" if attr? :float)].compact.join('; '))
+.imageblock(id=@id class=[@style,role] style=Helpers.style_value(text_align: (attr :align), float: (attr :float)))
   .content
     - if attr? :link
       a.image href=(attr :link)

--- a/slim/html5/block_table.html.slim
+++ b/slim/html5/block_table.html.slim
@@ -1,5 +1,5 @@
 table(id=@id class=['tableblock',"frame-#{attr :frame, 'all'}","grid-#{attr :grid, 'all'}",role]
-    style=[("width:#{attr :tablepcwidth}%" unless option? 'autowidth'),("float:#{attr :float}" if attr? :float)].compact.join('; '))
+      style=Helpers.style_value(width: ("#{attr :tablepcwidth}%" unless option? 'autowidth'), float: (attr :float)))
   - if title?
     caption.title=captioned_title
   - unless (attr :rowcount).zero?
@@ -26,7 +26,7 @@ table(id=@id class=['tableblock',"frame-#{attr :frame, 'all'}","grid-#{attr :gri
                   - cell_content = cell.content
               *{:tag=>(tblsec == :head || cell.style == :header ? 'th' : 'td'), :class=>['tableblock',"halign-#{cell.attr :halign}","valign-#{cell.attr :valign}"],
                   :colspan=>cell.colspan, :rowspan=>cell.rowspan,
-                  :style=>((@document.attr? :cellbgcolor) ? %(background-color:#{@document.attr :cellbgcolor};) : nil)}
+                  :style=>Helpers.style_value(background_color: @document.attr(:cellbgcolor))}
                 - if tblsec == :head
                   =cell_content
                 - else

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -3,6 +3,14 @@
 # (unless someone can show me how to include them in the evaluation context).
 # You can change the namespace to whatever you want.
 module Helpers
-  #def self.a_helper_function
-  #end
+
+  # Formats the given hash as CSS declarations for inline style.
+  def self.style_value(hash)
+    decls = []
+    hash.each do |prop, value|
+      prop = prop.to_s.gsub('_', '-')
+      decls << "#{prop}: #{value}" if value
+    end
+    decls.empty? ? nil : decls.join('; ') + ';'
+  end
 end

--- a/slim/html5/inline_image.html.slim
+++ b/slim/html5/inline_image.html.slim
@@ -1,4 +1,4 @@
-span class=[@type,role] style=("float: #{attr :float}" if attr? :float)
+span class=[@type,role] style=Helpers.style_value(float: (attr :float))
   - if @type == 'icon' && (@document.attr? :icons, 'font')
     - style_class = ["fa fa-#{@target}"]
     - style_class << "fa-#{attr :size}" if attr? :size


### PR DESCRIPTION
**Before:**

``` html
<div class="imageblock" style="">
  <div class="content">
    <img alt="sunset" src="sunset.jpg">
  </div>
</div>
```

**After:**

``` html
<div class="imageblock">
  <div class="content">
    <img alt="sunset" src="sunset.jpg">
  </div>
</div>
```
