### PR TITLE
Fix slim/html5/block_ulist – add space after marker

### DIFF
--- a/slim/html5/block_ulist.html.slim
+++ b/slim/html5/block_ulist.html.slim
@@ -6,7 +6,7 @@
     - if @document.attr? :icons, 'font'
       - marker_checked = '<i class="icon-check"></i>'
       - marker_unchecked = '<i class="icon-check-empty"></i>'
-    - else 
+    - else
       / could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
       - marker_checked = '<input type="checkbox" data-item-complete="1" checked disabled>'
       - marker_unchecked = '<input type="checkbox" data-item-complete="0" disabled>'
@@ -18,7 +18,7 @@
       li
         p
           - if checklist && (item.attr? :checkbox)
-            =%(#{(item.attr? :checked) ? marker_checked : marker_unchecked}#{item.text})
+            =%(#{(item.attr? :checked) ? marker_checked : marker_unchecked} #{item.text})
           - else
             =item.text
         - if item.blocks?


### PR DESCRIPTION
To be consistent with HAML and built-in versions of the template.
