### PR TITLE
Fix slim/html5/section – use :sectnumlevels attribute

### DIFF
--- a/slim/html5/section.html.slim
+++ b/slim/html5/section.html.slim
@@ -6,14 +6,15 @@
     - anchor = %(<a class="anchor" href="##{@id}"></a>)
     - link = nil
   - elsif @document.attr? :sectlinks
-    - anchor = nil 
+    - anchor = nil
     - link = %(<a class="link" href="##{@id}">)
 - if slevel == 0
   h1 id=@id class='sect0' =%(#{anchor}#{link}#{title}#{link && '</a>'})
   =content
 - else
   div class=["sect#{slevel}",role]
-    *{:tag=>"h#{slevel + 1}", :id=>@id} =%(#{anchor}#{link}#{@numbered ? "#{sectnum} " : nil}#{captioned_title}#{link && '</a>'})
+    - snum = @numbered && @caption.nil? && slevel <= @document.attr(:sectnumlevels, 3).to_i ? %(#{sectnum} ) : nil
+    *{:tag=>"h#{slevel + 1}", :id=>@id} =%(#{anchor}#{link}#{snum}#{captioned_title}#{link && '</a>'})
     - if slevel == 1
       .sectionbody=content
     - else


### PR DESCRIPTION
It’s just copied it from [HAML template](https://github.com/asciidoctor/asciidoctor-backends/blob/master/haml/html5/section.html.haml#L16) for now, I’ll rewrite it using helper method after merging [asciidoctor#1143](https://github.com/asciidoctor/asciidoctor/pull/1143).
