### PR TITLE
Fix haml/html5/inline_menu – don’t remove space after submenus

### DIFF
--- a/haml/html5/inline_menu.html.haml
+++ b/haml/html5/inline_menu.html.haml
@@ -4,7 +4,7 @@
   %span.menuseq
     %span.menu>=menu
     ='&#160;&#9656; '
-    =submenus.map {|submenu| %(<span class="submenu">#{submenu}</span>&#160;&#9656; ) }.join.chop
+    =submenus.map {|submenu| %(<span class="submenu">#{submenu}</span>&#160;&#9656; ) }.join
     %span.menuitem>=menuitem
 - elsif !menuitem.nil?
   %span.menuseq


### PR DESCRIPTION
Space after the last _submenu_ should not be removed, i.a. to be consistent with Slim and built-in version of the template.
