### PR TITLE
Replace form checkbox with unicode symbols in html5/block_ulist

### DIFF
--- a/haml/html5/block_ulist.html.haml
+++ b/haml/html5/block_ulist.html.haml
@@ -7,9 +7,8 @@
       - marker_checked = '<i class="icon-check"></i>'
       - marker_unchecked = '<i class="icon-check-empty"></i>'
     - else 
-      -# could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
-      - marker_checked = '<input type="checkbox" data-item-complete="1" checked disabled>'
-      - marker_unchecked = '<input type="checkbox" data-item-complete="0" disabled>'
+      - marker_checked = '&#10003;'
+      - marker_unchecked = '&#10063;'
 %div{:id=>@id, :class=>['ulist', checklist, @style, role]}
   - if title?
     .title=title

--- a/slim/html5/block_ulist.html.slim
+++ b/slim/html5/block_ulist.html.slim
@@ -7,9 +7,8 @@
       - marker_checked = '<i class="icon-check"></i>'
       - marker_unchecked = '<i class="icon-check-empty"></i>'
     - else
-      / could use &#9745 (checked ballot) and &#9744 (ballot) w/o font instead
-      - marker_checked = '<input type="checkbox" data-item-complete="1" checked disabled>'
-      - marker_unchecked = '<input type="checkbox" data-item-complete="0" disabled>'
+      - marker_checked = '&#10003;'
+      - marker_unchecked = '&#10063;'
 .ulist id=@id class=[checklist,@style,role]
   - if title?
     .title=title


### PR DESCRIPTION
Looks better and it’s also already used in the built-in version of the backend ([here](https://github.com/asciidoctor/asciidoctor/blob/v1.5.1/lib/asciidoctor/converter/html5.rb#L851-L852)).
