### PR TITLE
Remove webkitAllowFullScreen and mozallowfullscreen from block_video

### DIFF
--- a/haml/html5/block_video.html.haml
+++ b/haml/html5/block_video.html.haml
@@ -10,7 +10,7 @@
       - delimiter = '&amp;' if autoplay_param
       - loop_param = (option? :loop) ? "#{delimiter}loop=1" : nil
       - src = %(//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-      %iframe{:width=>(attr :width), :height=>(attr :height), :src=>src, :frameborder=>0, :webkitAllowFullScreen=>true, :mozallowfullscreen=>true, :allowFullScreen=>true}
+      %iframe{:width=>(attr :width), :height=>(attr :height), :src=>src, :frameborder=>0, :allowFullScreen=>!(option? :nofullscreen)}
     - when 'youtube'
       - params = ['rel=0']
       - params << "start=#{attr :start}" if attr? :start

--- a/slim/html5/block_video.html.slim
+++ b/slim/html5/block_video.html.slim
@@ -10,7 +10,7 @@
       - delimiter = '&amp;' if autoplay_param
       - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
       - src = %(//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 webkitAllowFullScreen=true mozallowfullscreen=true allowFullScreen=true
+      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 allowFullScreen=!(option? 'nofullscreen')
     - when 'youtube'
       - params = ['rel=0']
       - params << "start=#{attr :start}" if attr? :start

--- a/test/examples/html5/block_video.html
+++ b/test/examples/html5/block_video.html
@@ -43,21 +43,21 @@
 <!-- .vimeo -->
 <div class="videoblock">
   <div class="content">
-    <iframe allowFullScreen frameborder="0" mozallowfullscreen src="//player.vimeo.com/video/32255377" webkitAllowFullScreen></iframe>
+    <iframe allowFullScreen frameborder="0" src="//player.vimeo.com/video/32255377"></iframe>
   </div>
 </div>
 
 <!-- .vimeo-iframe-params -->
 <div class="videoblock">
   <div class="content">
-    <iframe allowFullScreen frameborder="0" height="480" mozallowfullscreen src="//player.vimeo.com/video/32255377" webkitAllowFullScreen width="640"></iframe>
+    <iframe frameborder="0" height="480" src="//player.vimeo.com/video/32255377" width="640"></iframe>
   </div>
 </div>
 
 <!-- .vimeo-url-params -->
 <div class="videoblock">
   <div class="content">
-    <iframe allowFullScreen frameborder="0" mozallowfullscreen src="//player.vimeo.com/video/32255377#at=60?autoplay=1&amp;loop=1" webkitAllowFullScreen></iframe>
+    <iframe allowFullScreen frameborder="0" src="//player.vimeo.com/video/32255377#at=60?autoplay=1&amp;loop=1"></iframe>
   </div>
 </div>
 


### PR DESCRIPTION
These attributes are already deprecated and not needed since [Firefox 18](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/18?redirectlocale=en-US&redirectslug=Firefox_18_for_developers#HTML) and [Chrome/Chromium 27](https://bugs.webkit.org/show_bug.cgi?id=110374).
