### PR TITLE
Fix html5/inline_callout – add “conum” class to b element when no icons

### DIFF
--- a/haml/html5/inline_callout.html.haml
+++ b/haml/html5/inline_callout.html.haml
@@ -4,4 +4,4 @@
 - elsif @document.attr? :icons
   %img{:src=>icon_uri("callouts/#{@text}"), :alt=>@text}
 - else
-  %b="(#{@text})"
+  %b.conum="(#{@text})"

--- a/slim/html5/inline_callout.html.slim
+++ b/slim/html5/inline_callout.html.slim
@@ -4,4 +4,4 @@
 - elsif @document.attr? :icons
   img src=icon_uri("callouts/#{@text}") alt=@text
 - else
-  b="(#{@text})"
+  b.conum ="(#{@text})"

--- a/test/examples/html5/inline_callout.html
+++ b/test/examples/html5/inline_callout.html
@@ -1,7 +1,7 @@
 <!-- .basic
 :include: .//code/node()
 -->
-"Hello world!" <b>(1)</b>
+"Hello world!" <b class="conum">(1)</b>
 
 <!-- .icons-image
 :include: .//code/node()


### PR DESCRIPTION
To be consistent with the built-in version of the template. Reflects [this](https://github.com/asciidoctor/asciidoctor/commit/2e68c355fea566002a07e2bc7a89d7bda81f5c8d) commit.
