### PR TITLE
Fix html5/block_{quote,verse} – output attribution in front of citetitle

### DIFF
--- a/haml/html5/block_quote.html.haml
+++ b/haml/html5/block_quote.html.haml
@@ -4,9 +4,9 @@
   %blockquote=content
   - if (attr? :attribution) or (attr? :citetitle)
     .attribution
-      - if attr? :citetitle
-        %cite=attr :citetitle
       - if attr? :attribution
-        - if attr? :citetitle
-          %br
         &#8212; #{attr :attribution}
+      - if attr? :citetitle
+        - if attr? :attribution
+          %br
+        %cite=attr :citetitle

--- a/haml/html5/block_verse.html.haml
+++ b/haml/html5/block_verse.html.haml
@@ -4,9 +4,9 @@
   %pre.content=content
   - if (attr? :attribution) or (attr? :citetitle)
     .attribution
-      - if attr? :citetitle
-        %cite=attr :citetitle
       - if attr? :attribution
-        - if attr? :citetitle
-          %br
         &#8212; #{attr :attribution}
+      - if attr? :citetitle
+        - if attr? :attribution
+          %br
+        %cite=attr :citetitle

--- a/slim/html5/block_quote.html.slim
+++ b/slim/html5/block_quote.html.slim
@@ -6,9 +6,9 @@
   - citetitle = (attr? :citetitle) ? (attr :citetitle) : nil
   - if attribution || citetitle
     .attribution
-      - if citetitle
-        cite=citetitle
       - if attribution
-        - if citetitle
-          br
         | &#8212; #{attribution}
+      - if citetitle
+        - if attribution
+          br
+        cite=citetitle

--- a/slim/html5/block_verse.html.slim
+++ b/slim/html5/block_verse.html.slim
@@ -6,9 +6,9 @@
   - citetitle = (attr? :citetitle) ? (attr :citetitle) : nil
   - if attribution || citetitle
     .attribution
-      - if citetitle
-        cite=citetitle
       - if attribution
-        - if citetitle
-          br
         | &#8212; #{attribution}
+      - if citetitle
+        - if attribution
+          br
+        cite=citetitle

--- a/test/examples/html5/block_quote.html
+++ b/test/examples/html5/block_quote.html
@@ -14,9 +14,8 @@ on this continent a new nation&#8230;&#8203;</blockquote>
 <div class="quoteblock">
   <blockquote>Everybody remember where we parked.</blockquote>
   <div class="attribution">
+    &#8212; Captain James T. Kirk<br>
     <cite>Star Trek IV: The Voyage Home</cite>
-    <br>
-    &#8212; Captain James T. Kirk
   </div>
 </div>
 

--- a/test/examples/html5/block_verse.html
+++ b/test/examples/html5/block_verse.html
@@ -16,9 +16,8 @@ on little cat feet.</pre>
   <pre class="content">The fog comes
 on little cat feet.</pre>
   <div class="attribution">
+    &#8212; Carl Sandburg<br>
     <cite>two lines from the poem Fog</cite>
-    <br>
-    &#8212; Carl Sandburg
   </div>
 </div>
 


### PR DESCRIPTION
To be consistent with the built-in version of the backend ([1ad4cbb9](https://github.com/asciidoctor/asciidoctor/commit/1ad4cbb949974b9addb85c459418b9218e683f1c)).
