### PR TITLE
Fix html5/block_toc – add title id named after toc id

### DIFF
--- a/haml/html5/block_toc.html.haml
+++ b/haml/html5/block_toc.html.haml
@@ -1,7 +1,7 @@
 - if @document.attr? :toc
   - toc_id = @id
   - toc_role = (attr 'role', (@document.attr 'toc-class', 'toc'))
-  - toc_title_id = nil
+  - toc_title_id = "#{toc_id}title" if toc_id
   - toc_title = title? ? title : (@document.attr 'toc-title')
   - if !toc_id && (@document.embedded? || !(@document.attr? 'toc-placement'))
     - toc_id = 'toc'

--- a/slim/html5/block_toc.html.slim
+++ b/slim/html5/block_toc.html.slim
@@ -1,7 +1,7 @@
 - if @document.attr? :toc
   - toc_id = @id
   - toc_role = (attr 'role', (@document.attr 'toc-class', 'toc'))
-  - toc_title_id = nil
+  - toc_title_id = "#{toc_id}title" if toc_id
   - toc_title = title? ? title : (@document.attr 'toc-title')
   - if !toc_id && (@document.embedded? || !(@document.attr? 'toc-placement'))
     - toc_id = 'toc'

--- a/test/examples/html5/block_toc.html
+++ b/test/examples/html5/block_toc.html
@@ -42,7 +42,7 @@
 :include: .//*[@id="my-toc"]
 -->
 <div class="awesome-toc" id="my-toc">
-  <div class="title">Table of Contents</div>
+  <div class="title" id="my-toctitle">Table of Contents</div>
   <ul class="sectlevel1">
     <li><a href="#_introduction">Introduction</a></li>
     <li><a href="#_cavern_glow">Cavern Glow</a></li>


### PR DESCRIPTION
To be consistent with the built-in version of the backend ([see there](https://github.com/asciidoctor/asciidoctor/blob/v1.5.1/lib/asciidoctor/converter/html5.rb#L814)).
