### PR TITLE
Fix html5/block_admonition – icons should have class “fa icon-”

### DIFF
--- a/haml/html5/block_admonition.html.haml
+++ b/haml/html5/block_admonition.html.haml
@@ -3,7 +3,7 @@
     %tr
       %td.icon
         - if @document.attr? :icons, 'font'
-          %i{:class=>"fa fa-#{attr :name}", :title=>@caption}
+          %i{:class=>"fa icon-#{attr :name}", :title=>@caption}
         - elsif @document.attr? :icons
           %img{:src=>icon_uri(attr :name), :alt=>@caption}
         - else

--- a/slim/html5/block_admonition.html.slim
+++ b/slim/html5/block_admonition.html.slim
@@ -2,7 +2,7 @@
   table: tr
     td.icon
       - if @document.attr? :icons, 'font'
-        i class=%(fa fa-#{attr :name}) title=@caption
+        i class=%(fa icon-#{attr :name}) title=@caption
       - elsif @document.attr? :icons
         img src=icon_uri(attr :name) alt=@caption
       - else

--- a/test/examples/html5/block_admonition.html
+++ b/test/examples/html5/block_admonition.html
@@ -93,7 +93,7 @@ at the beginning of the paragraph.
   <table>
     <tr>
       <td class="icon">
-        <i class="fa fa-warning" title="Warning"></i>
+        <i class="fa icon-warning" title="Warning"></i>
       </td>
       <td class="content">Watch out for dragons!</td>
     </tr>


### PR DESCRIPTION
I’ve incorrectly fixed it together with ulist markers in 2c004a3e9ce5b480beaf8bb77dfa0e4c374c9c92, but it actually should be “fa icon-” – according to [this line](https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/converter/html5.rb#L328) in the built-in and the stylesheet.
