### PR TITLE
Fix html5/inline_anchor – add id and title for other types

### DIFF
--- a/haml/html5/inline_anchor.html.haml
+++ b/haml/html5/inline_anchor.html.haml
@@ -8,4 +8,4 @@
   %a(id=@target)>
   =%([#{@target}])
 - else
-  %a(href=@target){:class=>role, :target=>(attr :window)}=@text
+  %a(href=@target){:id=>@id, :class=>role, :target=>(attr :window), :title=>(attr :title)}=@text

--- a/slim/html5/inline_anchor.html.slim
+++ b/slim/html5/inline_anchor.html.slim
@@ -8,4 +8,4 @@
   a id=@target
   |[#{@target}]
 - else
-  a href=@target class=role target=(attr :window) =@text
+  a id=@id class=role href=@target target=(attr :window) title=(attr :title) =@text


### PR DESCRIPTION
To be consistent with the built-in version of the backend ([here](https://github.com/asciidoctor/asciidoctor/blob/v1.5.1/lib/asciidoctor/converter/html5.rb#L955-L959)).
