### PR TITLE
Fix html5/document – cleanup header and add some meta tags

### DIFF
--- a/haml/html5/document.html.haml
+++ b/haml/html5/document.html.haml
@@ -1,12 +1,14 @@
 !!! 5
 %html{:lang=>(attr :lang, 'en')}
   %head
-    %meta(http-equiv='Content-Type' content="text/html; charset=#{attr :encoding}")
-    %meta(name='generator' content="Asciidoctor #{attr 'asciidoctor-version'}")
+    %meta(charset="#{attr :encoding, 'UTF-8'}")
+    /[if IE]
+      %meta(http-equiv="X-UA-Compatible" content="IE=edge")
     %meta(name='viewport' content='width=device-width, initial-scale=1.0')
-    - [:description, :keywords, :author, :copyright].each do |key|
+    %meta(name='generator' content="Asciidoctor #{attr 'asciidoctor-version'}")
+    - { 'app-name'=>'application-name', 'description'=>nil, 'keywords'=>nil, 'authors'=>'author', 'copyright'=>nil }.each do |key, meta|
       - if attr? key
-        %meta{:name=>key, :content=>(attr key)}
+        %meta{:name=>(meta || key), :content=>(attr key)}
     %title=((doctitle :sanitize => true) || (attr 'untitled-label'))
     - if Asciidoctor::DEFAULT_STYLESHEET_KEYS.include?(attr :stylesheet)
       - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)

--- a/slim/html5/document.html.slim
+++ b/slim/html5/document.html.slim
@@ -1,12 +1,14 @@
 doctype 5
 html lang=(attr :lang, 'en' unless attr? :nolang)
   head
-    meta http-equiv='Content-Type' content='text/html; charset=#{attr :encoding}'
-    meta name='generator' content="Asciidoctor #{attr 'asciidoctor-version'}"
+    meta charset=(attr :encoding, 'UTF-8')
+    /[if IE]
+      meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name='viewport' content='width=device-width, initial-scale=1.0'
-    - [:description, :keywords, :author, :copyright].each do |key|
+    meta name='generator' content="Asciidoctor #{attr 'asciidoctor-version'}"
+    - { 'app-name'=>'application-name', 'description'=>nil, 'keywords'=>nil, 'authors'=>'author', 'copyright'=>nil }.each do |key, meta|
       - if attr? key
-        meta name=key content=(attr key)
+        meta name=(meta || key) content=(attr key)
     title=((doctitle :sanitize => true) || (attr 'untitled-label'))
     - if Asciidoctor::DEFAULT_STYLESHEET_KEYS.include?(attr :stylesheet)
       - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)


### PR DESCRIPTION
To be consistent with the built-in version of the backend (based on [e37eb56](https://github.com/asciidoctor/asciidoctor/commit/e37eb56a0aa5c0dfa82c150caa50afbfad1c29ae#diff-df3b6463915cbe086c0286f7d27617d8), [402273b](https://github.com/asciidoctor/asciidoctor/commit/402273b05f0e48ae4c26a977583c613b6a664f87)).
