### PR TITLE
Refactor slim/html5 templates using Helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
   - 2.2.0
   - 2.0.0
   - jruby-head
+matrix:
+  allow_failures:
+    # fails due to missing pygments.rb
+    - rvm: jruby-head
 notifications:
   email: false
   irc: "irc.freenode.org#asciidoctor"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
-rvm: 2.1.0
-script: bundle exec rake test
+rvm:
+  - 2.2.0
+  - 2.0.0
+  - jruby-head
 notifications:
   email: false
   irc: "irc.freenode.org#asciidoctor"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 2.2.0
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,10 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'activesupport', '~> 3.1'
   gem 'asciidoctor', '~> 1.5'
-  gem 'asciidoctor-doctest', '1.0.0.rc.2'
+  gem 'asciidoctor-doctest', '1.0.0.rc.3'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
-  gem 'minitest', '~> 5.4'
-  gem 'minitest-rg', '~> 5.1'
   gem 'pygments.rb', '~> 0.6'
   gem 'rake', '~> 10.0'
   gem 'slim', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,13 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'asciidoctor', '~> 1.5'
+  gem 'asciidoctor', '~> 1.5', '>= 1.5.2'
   gem 'asciidoctor-doctest', '1.0.0.rc.3'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
   gem 'pygments.rb', '~> 0.6'
   gem 'rake', '~> 10.0'
-  gem 'slim', '~> 2.0'
+  gem 'slim', '~> 2.1'
   gem 'thread_safe', '~> 0.3.4'
   gem 'tilt', '~> 2.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'asciidoctor', '~> 1.5', '>= 1.5.2'
-  gem 'asciidoctor-doctest', '~> 1.5'
+  gem 'asciidoctor', '~> 1.5.2'
+  gem 'asciidoctor-doctest', '~> 1.5.0'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
   gem 'pygments.rb', '~> 0.6'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'asciidoctor', '~> 1.5.2'
-  gem 'asciidoctor-doctest', '~> 1.5.0'
+  gem 'asciidoctor-doctest', '~> 1.5.1.1'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
   gem 'pygments.rb', '~> 0.6'

--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,11 @@ group :test do
   gem 'asciidoctor-doctest', '~> 1.5.1.2'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
-  gem 'pygments.rb', '~> 0.6'
   gem 'rake', '~> 10.0'
   gem 'slim', '~> 2.1'
   gem 'thread_safe', '~> 0.3.4'
   gem 'tilt', '~> 2.0'
+
+  # doesn't work on JRuby
+  gem 'pygments.rb', '~> 0.6', platforms: [:ruby, :mswin, :mingw]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'asciidoctor', '~> 1.5.2'
-  gem 'asciidoctor-doctest', '~> 1.5.1.1'
+  gem 'asciidoctor-doctest', '~> 1.5.1.2'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
   gem 'pygments.rb', '~> 0.6'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'asciidoctor', '~> 1.5', '>= 1.5.2'
-  gem 'asciidoctor-doctest', '1.0.0.rc.3'
+  gem 'asciidoctor-doctest', '~> 1.5'
   gem 'coderay', '~> 1.1'
   gem 'haml', '~> 4.0'
   gem 'pygments.rb', '~> 0.6'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 #!/usr/bin/env rake
 
-Dir.glob('test/tasks/*.rake').each do |file|
+Dir['test/tasks/*.rake'].each do |file|
   import file
 end
 

--- a/haml/html5/block_outline.html.haml
+++ b/haml/html5/block_outline.html.haml
@@ -1,0 +1,9 @@
+- unless sections.empty?
+  - toclevels ||= (document.attr 'toclevels', 2).to_i
+  - slevel = section_level sections.first
+  %ul{:class=>"sectlevel#{slevel}"}
+    - sections.each do |sec|
+      %li
+        %a{:href=>"##{sec.id}"}= section_title sec
+        - if (sec.level < toclevels) && (child_toc = converter.convert sec, 'outline')
+          = child_toc

--- a/haml/html5/block_table.html.haml
+++ b/haml/html5/block_table.html.haml
@@ -1,11 +1,11 @@
-%table{:id=>@id, :class=>['tableblock', "frame-#{attr :frame, 'all'}", "grid-#{attr :grid, 'all'}", role],
-    :style=>((css_style = [("width: #{attr :tablepcwidth}%;" unless option? :autowidth),
+%table{:id=>@id, :class=>['tableblock', "frame-#{attr :frame, 'all'}", "grid-#{attr :grid, 'all'}", spread?, role],
+    :style=>((css_style = [("width: #{attr :tablepcwidth}%;" unless autowidth? || spread?),
                        ("float: #{attr :float};" if attr? :float)].compact * ' ').empty? ? nil : css_style)}
   - if title?
     %caption.title=captioned_title
   - unless (attr :rowcount).zero?
     %colgroup
-      - if option? :autowidth
+      - if autowidth?
         - @columns.each do
           %col
       - else

--- a/haml/html5/block_video.html.haml
+++ b/haml/html5/block_video.html.haml
@@ -2,26 +2,10 @@
   - if title?
     .title=captioned_title
   .content
-    - case attr :poster
-    - when 'vimeo'
-      - start_anchor = (attr? :start) ? "#at=#{attr :start}" : nil
-      - delimiter = '?'
-      - autoplay_param = (option? :autoplay) ? "#{delimiter}autoplay=1" : nil
-      - delimiter = '&amp;' if autoplay_param
-      - loop_param = (option? :loop) ? "#{delimiter}loop=1" : nil
-      - src = %(//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-      %iframe{:width=>(attr :width), :height=>(attr :height), :src=>src, :frameborder=>0, :allowFullScreen=>!(option? :nofullscreen)}
-    - when 'youtube'
-      - params = ['rel=0']
-      - params << "start=#{attr :start}" if attr? :start
-      - params << "end=#{attr :end}" if attr? :end
-      - params << "autoplay=1" if option? :autoplay
-      - params << "loop=1" if option? :loop
-      - params << "controls=0" if option? :nocontrols
-      - src = %(//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
-      %iframe{:width=>(attr :width), :height=>(attr :height), :src=>src, :frameborder=>0, :allowfullscreen=>!(option? :nofullscreen)}
+    - if video_iframe?
+      %iframe{:width=>(attr :width), :height=>(attr :height), :src=>video_uri, :frameborder=>0, :allowfullscreen=>!(option? :nofullscreen)}
     - else
-      %video{:src=>media_uri(attr :target), :width=>(attr :width), :height=>(attr :height),
+      %video{:src=>video_uri, :width=>(attr :width), :height=>(attr :height),
           :poster=>((attr :poster) ? media_uri(attr :poster) : nil), :autoplay=>(option? :autoplay),
           :controls=>!(option? :nocontrols), :loop=>(option? :loop)}
         Your browser does not support the video tag.

--- a/haml/html5/helpers.rb
+++ b/haml/html5/helpers.rb
@@ -2,6 +2,12 @@
 # templates. Within the template you can invoke them as top-level functions
 # just like the built-in helper functions that Haml provides.
 module Haml::Helpers
-  #def a_helper_function
-  #end
+
+  def autowidth?
+    option? :autowidth
+  end
+
+  def spread?
+    'spread' if !(option? 'autowidth') && (attr :tablepcwidth) == 100
+  end
 end

--- a/haml/html5/helpers.rb
+++ b/haml/html5/helpers.rb
@@ -3,6 +3,32 @@
 # just like the built-in helper functions that Haml provides.
 module Haml::Helpers
 
+  ##
+  # Returns corrected section level.
+  #
+  # @param sec [Asciidoctor::Section] the section node (default: self).
+  # @return [Integer]
+  #
+  def section_level(sec = self)
+    @_section_level ||= (sec.level == 0 && sec.special) ? 1 : sec.level
+  end
+
+  ##
+  # Returns the captioned section's title, optionally numbered.
+  #
+  # @param sec [Asciidoctor::Section] the section node (default: self).
+  # @return [String]
+  #
+  def section_title(sec = self)
+    sectnumlevels = document.attr(:sectnumlevels, 3).to_i
+
+    if sec.numbered && !sec.caption && sec.level <= sectnumlevels
+      [sec.sectnum, sec.captioned_title].join(' ')
+    else
+      sec.captioned_title
+    end
+  end
+
   #--------------------------------------------------------
   # block_table
   #

--- a/haml/html5/helpers.rb
+++ b/haml/html5/helpers.rb
@@ -3,11 +3,63 @@
 # just like the built-in helper functions that Haml provides.
 module Haml::Helpers
 
+  #--------------------------------------------------------
+  # block_table
+  #
+
   def autowidth?
     option? :autowidth
   end
 
   def spread?
     'spread' if !(option? 'autowidth') && (attr :tablepcwidth) == 100
+  end
+
+  #--------------------------------------------------------
+  # block_video
+  #
+
+  # @return [Boolean] +true+ if the video should be embedded in an iframe.
+  def video_iframe?
+    ['vimeo', 'youtube'].include?(attr :poster)
+  end
+
+  def video_uri
+    case (attr :poster, '').to_sym
+    when :vimeo
+      params = {
+        :autoplay => (1 if option? 'autoplay'),
+        :loop     => (1 if option? 'loop')
+      }
+      start_anchor = "#at=#{attr :start}" if attr? :start
+      "//player.vimeo.com/video/#{attr :target}#{start_anchor}#{url_query params}"
+
+    when :youtube
+      video_id, list_id = (attr :target).split('/', 2)
+      params = {
+        :rel      => 0,
+        :start    => (attr :start),
+        :end      => (attr :end),
+        :list     => (attr :list, list_id),
+        :autoplay => (1 if option? 'autoplay'),
+        :loop     => (1 if option? 'loop'),
+        :controls => (0 if option? 'nocontrols')
+      }
+      "//www.youtube.com/embed/#{video_id}#{url_query params}"
+    else
+      anchor = [(attr :start), (attr :end)].join(',').chomp(',')
+      anchor.prepend '#t=' unless anchor.empty?
+      media_uri "#{attr :target}#{anchor}"
+    end
+  end
+
+  # Formats URL query parameters.
+  def url_query(params)
+    str = params.map { |k, v|
+      next if v.nil? || v.to_s.empty?
+      [k, v] * '='
+    }.compact.join('&amp;')
+
+    str.prepend('?') unless str.empty?
   end
 end

--- a/slim/html5/_attribution.html.slim
+++ b/slim/html5/_attribution.html.slim
@@ -1,0 +1,10 @@
+- attribution = attr :attribution
+- citetitle = attr :citetitle
+- if attribution || citetitle
+  .attribution
+    - if attribution
+      | &#8212; #{attribution}
+    - if citetitle
+      - if attribution
+        br
+      cite =citetitle

--- a/slim/html5/_footer.html.slim
+++ b/slim/html5/_footer.html.slim
@@ -1,0 +1,9 @@
+#footer
+  #footer-text
+    - if attr? :revnumber
+      | #{attr 'version-label'} #{attr :revnumber}
+    - if attr? 'last-update-label'
+      br
+      | #{attr 'last-update-label'} #{attr :docdatetime}
+  - unless (docinfo_content = (docinfo :footer)).empty?
+    =docinfo_content

--- a/slim/html5/_footnotes.html.slim
+++ b/slim/html5/_footnotes.html.slim
@@ -1,0 +1,6 @@
+#footnotes
+  hr
+  - footnotes.each do |fn|
+    .footnote id=(footnote_id fn.index)
+      a href="##{footnoteref_id fn.index}" =fn.index
+      | . #{fn.text}

--- a/slim/html5/_hdlist.html.slim
+++ b/slim/html5/_hdlist.html.slim
@@ -1,0 +1,20 @@
+= block_with_title 'hdlist'
+  table
+    - if (attr? :labelwidth) || (attr? :itemwidth)
+      colgroup
+        col style=style_value(width: [(attr :labelwidth), '%'])
+        col style=style_value(width: [(attr :itemwidth), '%'])
+    - items.each do |terms, dd|
+      tr
+        td class=['hdlist1', ('strong' if option? 'strong')]
+          - terms = [*terms]
+          - terms.each_with_index do |dt, idx|
+            =dt.text
+            - unless idx >= terms.count - 1
+              br
+        td.hdlist2
+          - unless dd.nil?
+            - if dd.text?
+              p =dd.text
+            - if dd.blocks?
+              =dd.content

--- a/slim/html5/_header.html.slim
+++ b/slim/html5/_header.html.slim
@@ -1,0 +1,29 @@
+/ AsciiDoc leaves an empty header div even if there's no doctitle
+#header
+  - if has_header?
+    - unless notitle
+      h1 =header.title
+    - if [:author, :revnumber, :revdate, :revremark].any? {|a| attr? a }
+      .details
+        - if attr? :author
+          span.author#author =(attr :author)
+          br
+          - if attr? :email
+            span.email#email =sub_macros(attr :email)
+            br
+          - if (authorcount = (attr :authorcount).to_i) > 1
+            - (2..authorcount).each do |idx|
+              span.author id="author#{idx}" =(attr "author_#{idx}")
+              br
+              - if attr? "email_#{idx}"
+                span.email id="email#{idx}" =sub_macros(attr "email_#{idx}")
+        - if attr? :revnumber
+          span#revnumber #{((attr 'version-label') || '').downcase} #{attr :revnumber}#{',' if attr? :revdate}
+          '
+        - if attr? :revdate
+          span#revdate =attr :revdate
+        - if attr? :revremark
+          br
+          span#revremark =(attr :revremark)
+  - if (attr? :toc) && (attr? 'toc-placement', 'auto')
+    include _toc.html

--- a/slim/html5/_qanda.html.slim
+++ b/slim/html5/_qanda.html.slim
@@ -1,0 +1,11 @@
+= block_with_title 'qlist qanda'
+  ol
+    - items.each do |questions, answer|
+      li
+        - [*questions].each do |question|
+          p: em =question.text
+        - unless answer.nil?
+          - if answer.text?
+            p =answer.text
+          - if answer.blocks?
+            =answer.content

--- a/slim/html5/_toc.html.slim
+++ b/slim/html5/_toc.html.slim
@@ -1,0 +1,4 @@
+#toc class=(attr 'toc-class', 'toc')
+  #toctitle =(attr 'toc-title')
+  / Renders block_outline.html.
+  = converter.convert document, 'outline'

--- a/slim/html5/block_admonition.html.slim
+++ b/slim/html5/block_admonition.html.slim
@@ -1,13 +1,13 @@
-.admonitionblock id=@id class=[(attr :name),role]
+.admonitionblock id=id class=[(attr :name), role]
   table: tr
     td.icon
-      - if @document.attr? :icons, 'font'
-        i class=%(fa icon-#{attr :name}) title=@caption
-      - elsif @document.attr? :icons
-        img src=icon_uri(attr :name) alt=@caption
+      - if icons_font?
+        i class=%(fa icon-#{attr :name}) title=caption
+      - elsif icons?
+        img src=icon_uri(attr :name) alt=caption
       - else
-        .title=@caption
+        .title =caption
     td.content
       - if title?
-        .title=title
+        .title =title
       =content

--- a/slim/html5/block_audio.html.slim
+++ b/slim/html5/block_audio.html.slim
@@ -1,4 +1,4 @@
-= block_with_captitle ['audioblock', style]
+= block_with_captioned_title ['audioblock', style]
   .content
     audio(
         src=media_uri(attr :target)

--- a/slim/html5/block_audio.html.slim
+++ b/slim/html5/block_audio.html.slim
@@ -1,6 +1,8 @@
-.audioblock id=@id class=[@style,role]
-  - if title?
-    .title=captioned_title
+= block_with_captitle ['audioblock', style]
   .content
-    audio src=media_uri(attr :target) autoplay=(option? 'autoplay') controls=!(option? 'nocontrols') loop=(option? 'loop')
-      |Your browser does not support the audio tag.
+    audio(
+        src=media_uri(attr :target)
+        autoplay=(option? 'autoplay')
+        controls=!(option? 'nocontrols')
+        loop=(option? 'loop'))
+      | Your browser does not support the audio tag.

--- a/slim/html5/block_audio.html.slim
+++ b/slim/html5/block_audio.html.slim
@@ -1,4 +1,4 @@
-= block_with_captioned_title ['audioblock', style]
+= block_with_title ['audioblock', style]
   .content
     audio(
         src=media_uri(attr :target)

--- a/slim/html5/block_audio.html.slim
+++ b/slim/html5/block_audio.html.slim
@@ -1,4 +1,4 @@
-= block_with_title ['audioblock', style]
+= block_with_title :class=>['audioblock', style]
   .content
     audio(
         src=media_uri(attr :target)

--- a/slim/html5/block_colist.html.slim
+++ b/slim/html5/block_colist.html.slim
@@ -1,4 +1,4 @@
-= block_with_title ['colist', style]
+= block_with_title :class=>['colist', style]
   - if icons?
     table
       - items.to_enum.with_index 1 do |item, num|

--- a/slim/html5/block_colist.html.slim
+++ b/slim/html5/block_colist.html.slim
@@ -1,20 +1,16 @@
-.colist id=@id class=[@style,role]
-  - if title?
-    .title=title
-  - if @document.attr? :icons
-    - font_icons = @document.attr? :icons, 'font'
+= block_with_title ['colist', style]
+  - if icons?
     table
-      - items.each_with_index do |item, i|
-        - num = i + 1
+      - items.to_enum.with_index 1 do |item, num|
         tr
           td
-            - if font_icons
+            - if icons_font?
               i.conum data-value=num
-              b=num
+              b =num
             - else
-              img src=icon_uri("callouts/#{num}") alt=num
-          td=item.text
+              img src=(icon_uri "callouts/#{num}") alt=num
+          td =item.text
   - else
     ol
       - items.each do |item|
-        li: p=item.text
+        li: p =item.text

--- a/slim/html5/block_dlist.html.slim
+++ b/slim/html5/block_dlist.html.slim
@@ -4,7 +4,7 @@
 - when 'horizontal'
   include _hdlist.html
 - else
-  = block_with_title ['dlist', style]
+  = block_with_title :class=>['dlist', style]
     dl
       - items.each do |terms, dd|
         - [*terms].each do |dt|

--- a/slim/html5/block_dlist.html.slim
+++ b/slim/html5/block_dlist.html.slim
@@ -1,53 +1,17 @@
-- case @style
+- case style
 - when 'qanda'
-  .qlist id=@id class=['qanda',role]
-    - if title?
-      .title=title
-    ol
-      - items.each do |questions, answer|
-        li
-          - [*questions].each do |question|
-            p: em=question.text
-          - unless answer.nil?
-            - if answer.text?
-              p=answer.text
-            - if answer.blocks?
-              =answer.content
+  include _qanda.html
 - when 'horizontal'
-  .hdlist id=@id class=role
-    - if title?
-      .title=title
-    table
-      - if (attr? :labelwidth) || (attr? :itemwidth)
-        colgroup
-          col style=((attr? :labelwidth) ? %(width:#{(attr :labelwidth).chomp '%'}%;) : nil)
-          col style=((attr? :itemwidth) ? %(width:#{(attr :itemwidth).chomp '%'}%;) : nil)
-      - items.each do |terms, dd|
-        tr
-          td class=['hdlist1',('strong' if option? 'strong')]
-            - terms = [*terms]
-            - last_term = terms.last
-            - terms.each do |dt|
-              =dt.text
-              - if dt != last_term
-                br
-          td.hdlist2
-            - unless dd.nil?
-              - if dd.text?
-                p=dd.text
-              - if dd.blocks?
-                =dd.content
+  include _hdlist.html
 - else
-  .dlist id=@id class=[@style,role]
-    - if title?
-      .title=title
+  = block_with_title ['dlist', style]
     dl
       - items.each do |terms, dd|
         - [*terms].each do |dt|
-          dt class=('hdlist1' unless @style) =dt.text
+          dt class=('hdlist1' unless style) =dt.text
         - unless dd.nil?
           dd
             - if dd.text?
-              p=dd.text
+              p =dd.text
             - if dd.blocks?
               =dd.content

--- a/slim/html5/block_example.html.slim
+++ b/slim/html5/block_example.html.slim
@@ -1,2 +1,2 @@
-= block_with_captitle 'exampleblock'
+= block_with_captioned_title 'exampleblock'
   .content =content

--- a/slim/html5/block_example.html.slim
+++ b/slim/html5/block_example.html.slim
@@ -1,4 +1,2 @@
-.exampleblock id=@id class=role
-  - if title?
-    .title=captioned_title
-  .content=content
+= block_with_captitle 'exampleblock'
+  .content =content

--- a/slim/html5/block_example.html.slim
+++ b/slim/html5/block_example.html.slim
@@ -1,2 +1,2 @@
-= block_with_captioned_title 'exampleblock'
+= block_with_title 'exampleblock'
   .content =content

--- a/slim/html5/block_floating_title.html.slim
+++ b/slim/html5/block_floating_title.html.slim
@@ -1,1 +1,1 @@
-*{:tag=>"h#{@level + 1}", :id=>@id, :class=>[@style,role].compact} =title
+*{:tag=>"h#{level + 1}", :id=>id, :class=>[style, role].compact} =title

--- a/slim/html5/block_image.html.slim
+++ b/slim/html5/block_image.html.slim
@@ -1,6 +1,4 @@
-.imageblock id=id class=[style, role] style=style_value(text_align: (attr :align), float: (attr :float))
+= block_with_title({:class=>'imageblock', :style=>style_value(text_align: (attr :align), float: (attr :float))}, :bottom)
   .content
     = html_tag_if (attr? :link), :a, {:class=>'image', :href=>(attr :link)}
       img src=image_uri(attr :target) alt=(attr :alt) width=(attr :width) height=(attr :height)
-  - if title?
-    .title =captioned_title

--- a/slim/html5/block_image.html.slim
+++ b/slim/html5/block_image.html.slim
@@ -1,9 +1,6 @@
-.imageblock(id=@id class=[@style,role] style=Helpers.style_value(text_align: (attr :align), float: (attr :float)))
+.imageblock id=id class=[style, role] style=style_value(text_align: (attr :align), float: (attr :float))
   .content
-    - if attr? :link
-      a.image href=(attr :link)
-        img src=image_uri(attr :target) alt=(attr :alt) width=(attr :width) height=(attr :height)
-    - else
+    = html_tag_if (attr? :link), :a, {:class=>'image', :href=>(attr :link)}
       img src=image_uri(attr :target) alt=(attr :alt) width=(attr :width) height=(attr :height)
   - if title?
-    .title=captioned_title
+    .title =captioned_title

--- a/slim/html5/block_listing.html.slim
+++ b/slim/html5/block_listing.html.slim
@@ -1,31 +1,13 @@
-.listingblock id=@id class=role
-  - if title?
-    .title=captioned_title
+= block_with_captitle 'listingblock'
   .content
-    - nowrap = !(@document.attr? :prewrap) || (option? 'nowrap')
-    - if @style == 'source'
-      - code_lang = attr :language, nil, false
-      - code_class = ["language-#{code_lang}"] if code_lang
-      - pre_class = ['highlight']
-      - pre_lang = nil
-      - case document.attr 'source-highlighter'
-      - when 'coderay'
-        - pre_class.unshift 'CodeRay'
-        - code_class = nil
-      - when 'pygments'
-        - pre_class.unshift 'pygments'
-        - code_class = nil
-      - when 'highlightjs', 'highlight.js'
-        - pre_class.unshift 'highlightjs'
-      - when 'prettify'
-        - pre_class.unshift 'prettyprint'
-        - pre_class << 'linenums' if attr? :linenums
-      - when 'html-pipeline'
-        - pre_lang = code_lang
-        - code_class = code_lang = pre_class = nil
-        - nowrap = false
-      - pre_class << 'nowrap' if nowrap
-      pre class=pre_class lang=pre_lang
-        code class=code_class data-lang=code_lang =content
+    - if style == 'source'
+      - if highlighter == 'html-pipeline'
+        pre lang=source_lang
+          code =content
+      - else
+        - unless ['CodeRay', 'pygments'].include? highlighter
+          - code_class = "language-#{source_lang}" if source_lang
+        pre class=[highlighter, 'highlight', ('linenums' if attr? :linenums), nowrap?]
+          code class=code_class data-lang=source_lang =content
     - else
-      pre class=('nowrap' if nowrap) =content
+      pre class=nowrap? =content

--- a/slim/html5/block_listing.html.slim
+++ b/slim/html5/block_listing.html.slim
@@ -1,4 +1,4 @@
-= block_with_captioned_title 'listingblock'
+= block_with_title 'listingblock'
   .content
     - highlighter = document.attr 'source-highlighter'
     - if style == 'source' && highlighter == 'html-pipeline'

--- a/slim/html5/block_listing.html.slim
+++ b/slim/html5/block_listing.html.slim
@@ -1,13 +1,23 @@
 = block_with_captioned_title 'listingblock'
   .content
-    - if style == 'source'
-      - if highlighter == 'html-pipeline'
-        pre lang=source_lang
-          code =content
-      - else
-        - unless ['CodeRay', 'pygments'].include? highlighter
-          - code_class = "language-#{source_lang}" if source_lang
-        pre class=[highlighter, 'highlight', ('linenums' if attr? :linenums), nowrap?]
-          code class=code_class data-lang=source_lang =content
+    - highlighter = document.attr 'source-highlighter'
+    - if style == 'source' && highlighter == 'html-pipeline'
+      pre lang=source_lang
+        code =content
+    - elsif style == 'source'
+      - code_class = "language-#{source_lang}" if source_lang
+      - case highlighter
+      - when 'coderay'
+        - pre_class = 'CodeRay'
+        - code_class = nil
+      - when 'highlight.js'
+        - pre_class = 'highlightjs'
+      - when 'prettify'
+        - pre_class = 'prettyprint'
+      - when 'pygments'
+        - pre_class = 'pygments'
+        - code_class = nil
+      pre class=[pre_class, 'highlight', ('linenums' if attr? :linenums), nowrap?]
+        code class=code_class data-lang=source_lang =content
     - else
       pre class=nowrap? =content

--- a/slim/html5/block_listing.html.slim
+++ b/slim/html5/block_listing.html.slim
@@ -1,4 +1,4 @@
-= block_with_captitle 'listingblock'
+= block_with_captioned_title 'listingblock'
   .content
     - if style == 'source'
       - if highlighter == 'html-pipeline'

--- a/slim/html5/block_literal.html.slim
+++ b/slim/html5/block_literal.html.slim
@@ -1,4 +1,2 @@
-.literalblock id=@id class=role
-  - if title?
-    .title=title
-  .content: pre class=(!(@document.attr? :prewrap) || (option? 'nowrap') ? 'nowrap' : nil) =content
+= block_with_title 'literalblock'
+  .content: pre class=nowrap? =content

--- a/slim/html5/block_olist.html.slim
+++ b/slim/html5/block_olist.html.slim
@@ -1,4 +1,4 @@
-= block_with_title ['olist', style]
+= block_with_title :class=>['olist', style]
   ol class=style start=(attr :start) type=list_marker_keyword
     - items.each do |item|
       li

--- a/slim/html5/block_olist.html.slim
+++ b/slim/html5/block_olist.html.slim
@@ -1,9 +1,7 @@
-.olist id=@id class=[@style,role]
-  - if title?
-    .title=title
-  ol class=@style start=(attr :start) type=list_marker_keyword
+= block_with_title ['olist', style]
+  ol class=style start=(attr :start) type=list_marker_keyword
     - items.each do |item|
       li
-        p=item.text
+        p =item.text
         - if item.blocks?
           =item.content

--- a/slim/html5/block_open.html.slim
+++ b/slim/html5/block_open.html.slim
@@ -3,5 +3,5 @@
     = block_with_title 'quoteblock abstract'
       blockquote =content
 - elsif style != 'partintro' || partintro_allowed?
-  = block_with_title ['openblock', (style if style != 'open')]
+  = block_with_title :class=>['openblock', (style if style != 'open')]
     .content =content

--- a/slim/html5/block_open.html.slim
+++ b/slim/html5/block_open.html.slim
@@ -1,15 +1,7 @@
-- if @style == 'abstract'
-  - if @parent == @document && @document.doctype == 'book'
-    - puts 'asciidoctor: WARNING: abstract block cannot be used in a document without a title when doctype is book. Excluding block content.'
-  - else
-    .quoteblock.abstract id=@id class=role
-      - if title?
-        .title=title
-      blockquote=content
-- elsif @style == 'partintro' && (@level != 0 || @parent.context != :section || @document.doctype != 'book')
-  - puts 'asciidoctor: ERROR: partintro block can only be used when doctype is book and it\'s a child of a book part. Excluding block content.' 
-- else
-  .openblock id=@id class=[(@style != 'open' ? @style : nil),role]
-    - if title?
-      .title=title
-    .content=content
+- if style == 'abstract'
+  - if abstract_allowed?
+    = block_with_title 'quoteblock abstract'
+      blockquote =content
+- elsif style != 'partintro' || partintro_allowed?
+  = block_with_title ['openblock', (style if style != 'open')]
+    .content =content

--- a/slim/html5/block_outline.html.slim
+++ b/slim/html5/block_outline.html.slim
@@ -1,0 +1,9 @@
+- unless sections.empty?
+  - toclevels ||= (document.attr 'toclevels', DEFAULT_TOCLEVELS).to_i
+  - slevel = section_level sections.first
+  ul class="sectlevel#{slevel}"
+    - sections.each do |sec|
+      li
+        a href="##{sec.id}" =section_title sec
+        - if (sec.level < toclevels) && (child_toc = converter.convert sec, 'outline')
+          = child_toc

--- a/slim/html5/block_paragraph.html.slim
+++ b/slim/html5/block_paragraph.html.slim
@@ -1,4 +1,2 @@
-.paragraph id=@id class=role
-  - if title?
-    .title=title
-  p=content
+= block_with_title 'paragraph'
+  p =content

--- a/slim/html5/block_preamble.html.slim
+++ b/slim/html5/block_preamble.html.slim
@@ -1,6 +1,4 @@
 #preamble
-  .sectionbody=content
+  .sectionbody =content
   - if (attr? :toc) && (attr? 'toc-placement', 'preamble')
-    #toc class=(attr 'toc-class', 'toc')
-      #toctitle=(attr 'toc-title')
-      =converter.convert @document, 'outline'
+    include _toc.html

--- a/slim/html5/block_quote.html.slim
+++ b/slim/html5/block_quote.html.slim
@@ -1,14 +1,3 @@
-.quoteblock id=@id class=role
-  - if title?
-    .title=title
-  blockquote=content
-  - attribution = (attr? :attribution) ? (attr :attribution) : nil
-  - citetitle = (attr? :citetitle) ? (attr :citetitle) : nil
-  - if attribution || citetitle
-    .attribution
-      - if attribution
-        | &#8212; #{attribution}
-      - if citetitle
-        - if attribution
-          br
-        cite=citetitle
+= block_with_title 'quoteblock'
+  blockquote =content
+  include _attribution.html

--- a/slim/html5/block_sidebar.html.slim
+++ b/slim/html5/block_sidebar.html.slim
@@ -1,5 +1,5 @@
-.sidebarblock id=@id class=role
+.sidebarblock id=id class=role
   .content
     - if title?
-      .title=title
+      .title =title
     =content

--- a/slim/html5/block_stem.html.slim
+++ b/slim/html5/block_stem.html.slim
@@ -1,8 +1,2 @@
-- open, close = Asciidoctor::BLOCK_MATH_DELIMITERS[@style.to_sym]
-- equation = content
-- unless (equation.start_with? open) && (equation.end_with? close)
-  - equation = %(#{open}#{equation}#{close})
-.stemblock id=@id class=role
-  - if title?
-    .title=title
-  .content=equation
+= block_with_title 'stemblock'
+  .content =(delimit_stem content, style)

--- a/slim/html5/block_table.html.slim
+++ b/slim/html5/block_table.html.slim
@@ -1,42 +1,36 @@
-table(id=@id class=['tableblock',"frame-#{attr :frame, 'all'}","grid-#{attr :grid, 'all'}",role]
-      style=Helpers.style_value(width: ("#{attr :tablepcwidth}%" unless option? 'autowidth'), float: (attr :float)))
+table(id=id
+      class=['tableblock', "frame-#{attr :frame, 'all'}", "grid-#{attr :grid, 'all'}", role]
+      style=style_value(width: ("#{attr :tablepcwidth}%" unless option? 'autowidth'), float: (attr :float)))
   - if title?
-    caption.title=captioned_title
+    caption.title =captioned_title
   - unless (attr :rowcount).zero?
     colgroup
       - if option? 'autowidth'
-        - @columns.each do
+        - columns.each do
           col
       - else
-        - @columns.each do |col|
-          col style="width:#{col.attr :colpcwidth}%;"
-    - [:head, :foot, :body].select {|tblsec| !@rows[tblsec].empty? }.each do |tblsec|
+        - columns.each do |col|
+          col style="width: #{col.attr :colpcwidth}%;"
+    - [:head, :foot, :body].reject { |tblsec| rows[tblsec].empty? }.each do |tblsec|
       *{:tag=>"t#{tblsec}"}
-        - @rows[tblsec].each do |row|
+        - rows[tblsec].each do |row|
           tr
             - row.each do |cell|
-              / store reference of content in advance to resolve attribute assignments in cells
-              - if tblsec == :head
-                - cell_content = cell.text
-              - else
-                - case cell.style
-                - when :verse, :literal
-                  - cell_content = cell.text
-                - else
-                  - cell_content = cell.content
-              *{:tag=>(tblsec == :head || cell.style == :header ? 'th' : 'td'), :class=>['tableblock',"halign-#{cell.attr :halign}","valign-#{cell.attr :valign}"],
-                  :colspan=>cell.colspan, :rowspan=>cell.rowspan,
-                  :style=>Helpers.style_value(background_color: @document.attr(:cellbgcolor))}
+              *{:tag=>(tblsec == :head || cell.style == :header ? 'th' : 'td'),
+                  :class=>['tableblock', "halign-#{cell.attr :halign}", "valign-#{cell.attr :valign}"],
+                  :colspan=>cell.colspan,
+                  :rowspan=>cell.rowspan,
+                  :style=>style_value(background_color: (document.attr :cellbgcolor))}
                 - if tblsec == :head
-                  =cell_content
+                  =cell.text
                 - else
                   - case cell.style
                   - when :asciidoc
-                    div=cell_content
+                    div =cell.content
                   - when :verse
-                    .verse=cell_content
+                    .verse =cell.text
                   - when :literal
-                    .literal: pre=cell_content
+                    .literal: pre =cell.text
                   - else
-                    - cell_content.each do |text|
-                      p.tableblock=text
+                    - cell.content.each do |text|
+                      p.tableblock =text

--- a/slim/html5/block_table.html.slim
+++ b/slim/html5/block_table.html.slim
@@ -1,11 +1,11 @@
 table(id=id
-      class=['tableblock', "frame-#{attr :frame, 'all'}", "grid-#{attr :grid, 'all'}", role]
-      style=style_value(width: ("#{attr :tablepcwidth}%" unless option? 'autowidth'), float: (attr :float)))
+      class=['tableblock', "frame-#{attr :frame, 'all'}", "grid-#{attr :grid, 'all'}", spread?, role]
+      style=style_value(width: ("#{attr :tablepcwidth}%" unless autowidth? || spread?), float: (attr :float)))
   - if title?
     caption.title =captioned_title
   - unless (attr :rowcount).zero?
     colgroup
-      - if option? 'autowidth'
+      - if autowidth?
         - columns.each do
           col
       - else

--- a/slim/html5/block_toc.html.slim
+++ b/slim/html5/block_toc.html.slim
@@ -1,11 +1,8 @@
-- if @document.attr? :toc
-  - toc_id = @id
-  - toc_role = (attr 'role', (@document.attr 'toc-class', 'toc'))
-  - toc_title_id = "#{toc_id}title" if toc_id
-  - toc_title = title? ? title : (@document.attr 'toc-title')
-  - if !toc_id && (@document.embedded? || !(@document.attr? 'toc-placement'))
-    - toc_id = 'toc'
-    - toc_title_id = 'toctitle'
-  div id=toc_id class=toc_role
-    .title id=toc_title_id =toc_title
-    =converter.convert_with_options @document, 'outline', :toclevels => ((attr? :levels) ? (attr :levels).to_i : nil)
+/ This template is used only for toc::[] macro; for document and preamble TOC
+/ see document.html, preamble.html and _toc.html.
+- if document.attr? :toc
+  - toc_id = id || ('toc' if document.embedded? || !document.attr?('toc-placement'))
+  div id=toc_id class=(attr :role, (document.attr 'toc-class', 'toc'))
+    .title id=("#{toc_id}title" if toc_id) =(title || (document.attr 'toc-title'))
+    / Renders block_outline.html.
+    = converter.convert_with_options document, 'outline', :toclevels=>((attr :levels).to_i if attr? :levels)

--- a/slim/html5/block_ulist.html.slim
+++ b/slim/html5/block_ulist.html.slim
@@ -8,7 +8,7 @@
   - else
     - marker_checked = '&#10003;'
     - marker_unchecked = '&#10063;'
-= block_with_title ['ulist', checklist, style]
+= block_with_title :class=>['ulist', checklist, style]
   ul class=(checklist || style)
     - items.each do |item|
       li

--- a/slim/html5/block_ulist.html.slim
+++ b/slim/html5/block_ulist.html.slim
@@ -1,23 +1,23 @@
-- if (checklist = (option? 'checklist') ? 'checklist' : nil)
+- if (checklist = 'checklist' if option? 'checklist')
   - if option? 'interactive'
-    - marker_checked = '<input type="checkbox" data-item-complete="1" checked>'
-    - marker_unchecked = '<input type="checkbox" data-item-complete="0">'
+    - marker_checked = html_tag 'input', :type=>'checkbox', 'data-item-complete'=>'1', :checked=>true
+    - marker_unchecked = html_tag 'input', :type=>'checkbox', 'data-item-complete'=>'0'
+  - elsif icons_font?
+    - marker_checked = html_tag 'i', :class=>'fa fa-check-square-o'
+    - marker_unchecked = html_tag 'i', :class=>'fa fa-square-o'
   - else
-    - if @document.attr? :icons, 'font'
-      - marker_checked = '<i class="fa fa-check-square-o"></i>'
-      - marker_unchecked = '<i class="fa fa-square-o"></i>'
-    - else
-      - marker_checked = '&#10003;'
-      - marker_unchecked = '&#10063;'
-.ulist id=@id class=[checklist,@style,role]
-  - if title?
-    .title=title
-  ul class=(checklist || @style)
+    - marker_checked = '&#10003;'
+    - marker_unchecked = '&#10063;'
+= block_with_title ['ulist', checklist, style]
+  ul class=(checklist || style)
     - items.each do |item|
       li
         p
           - if checklist && (item.attr? :checkbox)
-            =%(#{(item.attr? :checked) ? marker_checked : marker_unchecked} #{item.text})
+            - if item.attr? :checked
+              | #{marker_checked} #{item.text}
+            - else
+              | #{marker_unchecked} #{item.text}
           - else
             =item.text
         - if item.blocks?

--- a/slim/html5/block_verse.html.slim
+++ b/slim/html5/block_verse.html.slim
@@ -1,14 +1,3 @@
-.verseblock id=@id class=role
-  - if title?
-    .title=title
-  pre.content=content
-  - attribution = (attr? :attribution) ? (attr :attribution) : nil
-  - citetitle = (attr? :citetitle) ? (attr :citetitle) : nil
-  - if attribution || citetitle
-    .attribution
-      - if attribution
-        | &#8212; #{attribution}
-      - if citetitle
-        - if attribution
-          br
-        cite=citetitle
+= block_with_title 'verseblock'
+  pre.content =content
+  include _attribution.html

--- a/slim/html5/block_video.html.slim
+++ b/slim/html5/block_video.html.slim
@@ -1,4 +1,4 @@
-= block_with_title ['videoblock', style]
+= block_with_title :class=>['videoblock', style]
   .content
     - if video_iframe?
       iframe(

--- a/slim/html5/block_video.html.slim
+++ b/slim/html5/block_video.html.slim
@@ -1,27 +1,19 @@
-.videoblock id=@id class=[@style,role]
-  - if title?
-    .title=captioned_title
+= block_with_captitle ['videoblock', style]
   .content
-    - case attr :poster
-    - when 'vimeo'
-      - start_anchor = (attr? :start) ? "#at=#{attr :start}" : nil
-      - delimiter = '?'
-      - autoplay_param = (option? 'autoplay') ? "#{delimiter}autoplay=1" : nil
-      - delimiter = '&amp;' if autoplay_param
-      - loop_param = (option? 'loop') ? "#{delimiter}loop=1" : nil
-      - src = %(//player.vimeo.com/video/#{attr :target}#{start_anchor}#{autoplay_param}#{loop_param})
-      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 allowFullScreen=!(option? 'nofullscreen')
-    - when 'youtube'
-      - params = ['rel=0']
-      - params << "start=#{attr :start}" if attr? :start
-      - params << "end=#{attr :end}" if attr? :end
-      - params << "autoplay=1" if option? 'autoplay'
-      - params << "loop=1" if option? 'loop'
-      - params << "controls=0" if option? 'nocontrols'
-      - src = %(//www.youtube.com/embed/#{attr :target}?#{params * '&amp;'})
-      iframe width=(attr :width) height=(attr :height) src=src frameborder=0 allowfullscreen=!(option? 'nofullscreen')
+    - if video_iframe?
+      iframe(
+          src=video_uri
+          width=(attr :width)
+          height=(attr :height)
+          frameborder=0
+          allowfullscreen=!(option? 'nofullscreen'))
     - else
-      video(src=media_uri(attr :target) width=(attr :width) height=(attr :height)
-          poster=((attr :poster) ? media_uri(attr :poster) : nil) autoplay=(option? 'autoplay')
-          controls=!(option? 'nocontrols') loop=(option? 'loop'))
-        |Your browser does not support the video tag.
+      video(
+          src=video_uri
+          width=(attr :width)
+          height=(attr :height)
+          poster=(media_uri(attr :poster) if attr? :poster)
+          autoplay=(option? 'autoplay')
+          controls=!(option? 'nocontrols')
+          loop=(option? 'loop'))
+        | Your browser does not support the video tag.

--- a/slim/html5/block_video.html.slim
+++ b/slim/html5/block_video.html.slim
@@ -1,4 +1,4 @@
-= block_with_captitle ['videoblock', style]
+= block_with_captioned_title ['videoblock', style]
   .content
     - if video_iframe?
       iframe(

--- a/slim/html5/block_video.html.slim
+++ b/slim/html5/block_video.html.slim
@@ -1,4 +1,4 @@
-= block_with_captioned_title ['videoblock', style]
+= block_with_title ['videoblock', style]
   .content
     - if video_iframe?
       iframe(

--- a/slim/html5/document.html.slim
+++ b/slim/html5/document.html.slim
@@ -6,110 +6,23 @@ html lang=(attr :lang, 'en' unless attr? :nolang)
       meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name='viewport' content='width=device-width, initial-scale=1.0'
     meta name='generator' content="Asciidoctor #{attr 'asciidoctor-version'}"
-    - { 'app-name'=>'application-name', 'description'=>nil, 'keywords'=>nil, 'authors'=>'author', 'copyright'=>nil }.each do |key, meta|
-      - if attr? key
-        meta name=(meta || key) content=(attr key)
-    title=((doctitle :sanitize => true) || (attr 'untitled-label'))
-    - if Asciidoctor::DEFAULT_STYLESHEET_KEYS.include?(attr :stylesheet)
-      - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)
-        link rel='stylesheet' href=normalize_web_path(Asciidoctor::DEFAULT_STYLESHEET_NAME, (attr :stylesdir, ''))
-      - else
-        style=Asciidoctor::Stylesheets.instance.primary_stylesheet_data
-    - elsif attr? :stylesheet
-      - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)
-        link rel='stylesheet' href=normalize_web_path((attr :stylesheet), (attr :stylesdir, ''))
-      - else
-        style=read_asset(normalize_system_path((attr :stylesheet), (attr :stylesdir, '')), true)
-    - if attr? :icons, 'font'
-      - if !(attr 'iconfont-remote', '').nil?
-        link rel='stylesheet' href=(attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css')
-      - else
-        link rel='stylesheet' href=normalize_web_path("#{attr 'iconfont-name', 'font-awesome'}.css", (attr :stylesdir, ''))
-    - case attr 'source-highlighter'
-    - when 'coderay'
-      - if (attr 'coderay-css', 'class') == 'class'
-        - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)
-          link rel='stylesheet' href=normalize_web_path('asciidoctor-coderay.css', (attr :stylesdir, ''))
-        - else
-          style=Asciidoctor::Stylesheets.instance.coderay_stylesheet_data
-    - when 'pygments'
-      - if (attr 'pygments-css', 'class') == 'class'
-        - if @safe >= Asciidoctor::SafeMode::SECURE || (attr? :linkcss)
-          link rel='stylesheet' href=normalize_web_path('asciidoctor-pygments.css', (attr :stylesdir, ''))
-        - else
-          style=Asciidoctor::Stylesheets.instance.pygments_stylesheet_data(attr 'pygments-style')
-    - when 'highlightjs'
-      link rel='stylesheet' href="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/styles/#{attr 'highlightjs-theme', 'googlecode'}.min.css"
-      script src="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/highlight.min.js"
-      script src="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/lang/common.min.js"
-      script hljs.initHighlightingOnLoad()
-    - when 'prettify'
-      link rel='stylesheet' href="#{attr :prettifydir, 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/#{attr 'prettify-theme', 'prettify'}.min.css"
-      script src="#{attr :prettifydir, 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/prettify.min.js"
-      script document.addEventListener('DOMContentLoaded', prettyPrint)
-    - if attr? 'stem'
-      script type='text/x-mathjax-config'
-        |MathJax.Hub.Config({
-           tex2jax: {
-             inlineMath: [['\\(','\\)']],
-             displayMath: [['\\[','\\]']],
-             ignoreClass: 'nostem|nolatexmath'
-           },
-           asciimath2jax: {
-             delimiters: [['\\$','\\$']],
-             ignoreClass: 'nostem|noasciimath'
-           }
-         });
-      script type='text/javascript' src='http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML'
+    = html_meta_if 'application-name', (attr 'app-name')
+    = html_meta_if 'author', (attr :authors)
+    = html_meta_if 'copyright', (attr :copyright)
+    = html_meta_if 'description', (attr :description)
+    = html_meta_if 'keywords', (attr :keywords)
+    title=((doctitle sanitize: true) || (attr 'untitled-label'))
+    = styles_and_scripts
     - unless (docinfo_content = docinfo).empty?
       =docinfo_content
-  body id=@id class=[(attr :doctype),((attr? 'toc-class') && (attr? :toc) && (attr? 'toc-placement', 'auto') ? "#{attr 'toc-class'} toc-#{attr 'toc-position', 'left'}" : nil)] style=("max-width: #{attr 'max-width'};" if attr? 'max-width')
+  body(
+    id=id
+    class=[(attr :doctype), ("#{attr 'toc-class'} toc-#{attr 'toc-position', 'left'}" if (attr? 'toc-class') && (attr? :toc) && (attr? 'toc-placement', 'auto'))]
+    style=style_value(max_width: (attr 'max-width')))
     - unless noheader
-      / AsciiDoc leaves an empty header div even if there's no doctitle
-      #header
-        - if has_header?
-          - unless notitle
-            h1=@header.title
-          - if (attr? :author) || (attr? :revnumber) || (attr? :revdate) || (attr? :revremark)
-            .details
-              - if attr? :author
-                span.author#author =(attr :author)
-                br
-                - if attr? :email
-                  span.email#email =sub_macros(attr :email)
-                  br
-                - if (authorcount = (attr :authorcount).to_i) > 1
-                  - (2..authorcount).each do |idx|
-                    span.author id="author#{idx}" =(attr "author_#{idx}")
-                    br
-                    - if attr? "email_#{idx}"
-                      span.email id="email#{idx}" =sub_macros(attr "email_#{idx}")
-              - if attr? :revnumber
-                span#revnumber #{((attr 'version-label') || '').downcase} #{attr :revnumber}#{',' if attr? :revdate}
-                '
-              - if attr? :revdate
-                span#revdate=attr :revdate
-              - if attr? :revremark
-                br
-                span#revremark=attr :revremark
-        - if (attr? :toc) && (attr? 'toc-placement', 'auto')
-          #toc class=(attr 'toc-class', 'toc')
-            #toctitle=attr 'toc-title'
-            =converter.convert self, 'outline'
-    #content=content
-    - unless !footnotes? || attr?(:nofootnotes)
-      #footnotes
-        hr
-        - footnotes.each do |fn|
-          .footnote id='_footnote_#{fn.index}'
-            <a href="#_footnoteref_#{fn.index}">#{fn.index}</a>. #{fn.text}
+      include _header.html
+    #content =content
+    - unless !footnotes? || (attr? :nofootnotes)
+      include _footnotes.html
     - unless nofooter
-      #footer
-        #footer-text
-          - if attr? :revnumber
-            | #{attr 'version-label'} #{attr :revnumber}
-          - if attr? 'last-update-label'
-            br
-            | #{attr 'last-update-label'} #{attr :docdatetime}
-        - unless (docinfo_content = (docinfo :footer)).empty?
-          =docinfo_content
+      include _footer.html

--- a/slim/html5/embedded.html.slim
+++ b/slim/html5/embedded.html.slim
@@ -1,9 +1,5 @@
 - unless notitle || !has_header?
-  h1 id=@id =@header.title
+  h1 id=id =header.title
 =content
-- unless !footnotes? || attr?(:nofootnotes)
-  #footnotes
-    hr
-    - footnotes.each do |fn|
-      .footnote id='_footnote_#{fn.index}'
-        <a href="#_footnoteref_#{fn.index}">#{fn.index}</a>. #{fn.text}
+- unless !footnotes? || (attr? :nofootnotes)
+  include _footnotes.html

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -127,8 +127,12 @@ module Slim::Helpers
 
   ##
   # Wraps a block in a div element with the specified class and optionally
-  # the node's +id+ and +role+(s). If the node's +title+ is not empty, then a
-  # nested div with the class "title" and the title's content is added as well.
+  # the node's +id+ and +role+(s). If the node's +captioned_title+ is not
+  # empty, than a nested div with the class "title" and the title's content
+  # is added as well.
+  #
+  # Note: Every node has method +captioned_title+; if it doesn't have a
+  # caption, then this method returns just a naked title.
   #
   # @example When @id, @role and @title attributes are set.
   #   = block_with_title ['quoteblock', 'center']
@@ -148,32 +152,20 @@ module Slim::Helpers
   #   </div>
   #
   # @param klass [Array<String>, String] the tag's class (default: []).
-  # @param title [String, nil] the title (default: @title).
   # @yield The block of Slim/HTML code within the tag (optional).
   # @return [String] a rendered HTML fragment.
   #
-  def block_with_title(klass = [], title = @title, &block)
+  def block_with_title(klass = [], &block)
     klass = klass.split(' ') if klass.is_a? String
     attrs = { id: id, class: [klass, role].flatten.uniq }
 
     html_tag 'div', attrs do
-      if title.nil_or_empty?
+      if captioned_title.nil_or_empty?
         yield
       else
-        html_tag('div', class: 'title') { title } + yield
+        html_tag('div', class: 'title') { captioned_title } + yield
       end
     end
-  end
-
-  ##
-  # Same as {#block_with_title}, but uses +captioned_title+ as a title.
-  #
-  # @param klass [Array<String>, String] the style classes (default: [])
-  # @yieldreturn [String] HTML fragment to be wrapped.
-  # @return [String] HTML
-  #
-  def block_with_captioned_title(klass = [], &block)
-    block_with_title klass, captioned_title, &block
   end
 
   ##

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -375,16 +375,19 @@ is book and it's a child of a book part. Excluding block content."
       }
       start_anchor = "#at=#{attr :start}" if attr? :start
       "//player.vimeo.com/video/#{attr :target}#{start_anchor}#{url_query params}"
+
     when :youtube
+      video_id, list_id = (attr :target).split('/', 2)
       params = {
         :rel      => 0,
         :start    => (attr :start),
         :end      => (attr :end),
+        :list     => (attr :list, list_id),
         :autoplay => (1 if option? 'autoplay'),
         :loop     => (1 if option? 'loop'),
         :controls => (0 if option? 'nocontrols')
       }
-      "//www.youtube.com/embed/#{attr :target}#{url_query params}"
+      "//www.youtube.com/embed/#{video_id}#{url_query params}"
     else
       media_uri(attr :target)
     end

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -172,7 +172,7 @@ module Slim::Helpers
   # @yieldreturn [String] HTML fragment to be wrapped.
   # @return [String] HTML
   #
-  def block_with_captitle(klass = [], &block)
+  def block_with_captioned_title(klass = [], &block)
     block_with_title klass, captioned_title, &block
   end
 

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -389,7 +389,9 @@ is book and it's a child of a book part. Excluding block content."
       }
       "//www.youtube.com/embed/#{video_id}#{url_query params}"
     else
-      media_uri(attr :target)
+      anchor = [(attr :start), (attr :end)].join(',').chomp(',')
+      anchor.prepend '#t=' unless anchor.empty?
+      media_uri "#{attr :target}#{anchor}"
     end
   end
 

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -1,16 +1,518 @@
-# Add custom functions to this module that you want to use in your Slim
-# templates. Within the template you must namespace the function
-# (unless someone can show me how to include them in the evaluation context).
-# You can change the namespace to whatever you want.
-module Helpers
+require 'asciidoctor'
+require 'json'
 
-  # Formats the given hash as CSS declarations for inline style.
-  def self.style_value(hash)
-    decls = []
-    hash.each do |prop, value|
-      prop = prop.to_s.gsub('_', '-')
-      decls << "#{prop}: #{value}" if value
+if Gem::Version.new(Asciidoctor::VERSION) <= Gem::Version.new('1.5.1')
+  fail 'asciidoctor: FAILED: HTML5/Slim backend needs Asciidoctor >=1.5.2!'
+end
+
+unless defined? Slim::Include
+  fail 'asciidoctor: FAILED: HTML5/Slim backend needs Slim >= 2.1.0!'
+end
+
+# Add custom functions to this module that you want to use in your Slim
+# templates. Within the template you can invoke them as top-level functions
+# just like in Haml.
+module Slim::Helpers
+
+  # URIs of external assets.
+  FONT_AWESOME_URI     = '//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css'
+  HIGHLIGHTJS_BASE_URI = '//cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'
+  MATHJAX_JS_URI       = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML'
+  PRETTIFY_BASE_URI    = '//cdnjs.cloudflare.com/ajax/libs/prettify/r298'
+
+  # Defaults
+  DEFAULT_HIGHLIGHTJS_THEME = 'github'
+  DEFAULT_PRETTIFY_THEME = 'prettify'
+  DEFAULT_SECTNUMLEVELS = 3
+  DEFAULT_TOCLEVELS = 2
+
+  # The MathJax configuration.
+  MATHJAX_CONFIG = {
+    tex2jax: {
+      inlineMath:  [::Asciidoctor::INLINE_MATH_DELIMITERS[:latexmath]],
+      displayMath: [::Asciidoctor::BLOCK_MATH_DELIMITERS[:latexmath]],
+      ignoreClass: 'nostem|nolatexmath'
+    },
+    asciimath2jax: {
+      delimiters:  [::Asciidoctor::BLOCK_MATH_DELIMITERS[:asciimath]],
+      ignoreClass: 'nostem|noasciimath'
+    }
+  }.to_json
+
+  VOID_ELEMENTS = %w(area base br col command embed hr img input keygen link meta param source track wbr)
+
+
+  ##
+  # Creates an HTML tag with the given name and optionally attributes. Can take
+  # a block that will run between the opening and closing tags.
+  #
+  # @param name [#to_s] the name of the tag.
+  # @param attributes [Hash] (default: {})
+  # @yield The block of Slim/HTML code within the tag (optional).
+  # @return [String] a rendered HTML element.
+  #
+  def html_tag(name, attributes = {})
+    attrs = attributes.reject { |_, v|
+      v.nil? || (v.respond_to?(:empty?) && v.empty?)
+    }.map do |k, v|
+      v = v.compact.join(' ') if v.is_a? Array
+      v = nil if v == true
+      v = %("#{v}") if v
+      [k, v] * '='
     end
+    attrs_str = attrs.empty? ? '' : attrs.join(' ').prepend(' ')
+
+    if VOID_ELEMENTS.include? name.to_s
+      %(<#{name}#{attrs_str}>)
+    else
+      content = block_given? ? yield : ''
+      %(<#{name}#{attrs_str}>#{content}</#{name}>)
+    end
+  end
+
+  ##
+  # Conditionally wraps a block in an element. If condition is +true+ then it
+  # renders the specified tag with optional attributes and the given
+  # block inside, otherwise it just renders the block.
+  #
+  # For example:
+  #
+  #    = html_tag_if link?, 'a', {class: 'image', href: (attr :link)}
+  #      img src='./img/tux.png'
+  #
+  # will produce:
+  #
+  #    <a href="http://example.org" class="image">
+  #      <img src="./img/tux.png">
+  #    </a>
+  #
+  # if +link?+ is truthy, and just
+  #
+  #   <img src="./img/tux.png">
+  #
+  # otherwise.
+  #
+  # @param condition [Boolean] the condition to test to determine whether to
+  #        render the enclosing tag.
+  # @param name (see #html_tag)
+  # @param attributes (see #html_tag)
+  # @yield (see #html_tag)
+  # @return [String] a rendered HTML fragment.
+  #
+  def html_tag_if(condition, name, attributes = {}, &block)
+    if condition
+      html_tag name, attributes, &block
+    else
+      yield
+    end
+  end
+
+  ##
+  # Surrounds a block with strings, with no whitespace in between.
+  #
+  # @example
+  #   = surround '[', ']' do
+  #     a href="#_footnote_1" 1
+  #
+  #   [<a href="#_footnote_1">1</a>]
+  #
+  # @param front [String] the string to add before the block.
+  # @param back [String] the string to add after the block.
+  # @yield The block of Slim/HTML code to surround.
+  # @return [String] a rendered HTML fragment.
+  #
+  def surround(front, back = front)
+    [front, yield.chomp, back].join
+  end
+
+  ##
+  # Wraps a block in a div element with the specified class and optionally
+  # the node's +id+ and +role+(s). If the node's +title+ is not empty, then a
+  # nested div with the class "title" and the title's content is added as well.
+  #
+  # @example When @id, @role and @title attributes are set.
+  #   = block_with_title ['quoteblock', 'center']
+  #     blockquote =content
+  #
+  #   <div id="myid" class="quoteblock center myrole1 myrole2">
+  #     <div class="title">Block Title</div>
+  #     <blockquote>Lorem ipsum</blockquote>
+  #   </div>
+  #
+  # @example When @id, @role and @title attributes are empty.
+  #   = block_with_title 'quoteblock center'
+  #     blockquote =content
+  #
+  #   <div class="quoteblock center">
+  #     <blockquote>Lorem ipsum</blockquote>
+  #   </div>
+  #
+  # @param klass [Array<String>, String] the tag's class (default: []).
+  # @param title [String, nil] the title (default: @title).
+  # @yield The block of Slim/HTML code within the tag (optional).
+  # @return [String] a rendered HTML fragment.
+  #
+  def block_with_title(klass = [], title = @title, &block)
+    klass = klass.split(' ') if klass.is_a? String
+    attrs = { id: id, class: [klass, role].flatten.uniq }
+
+    html_tag 'div', attrs do
+      if title.nil_or_empty?
+        yield
+      else
+        html_tag('div', class: 'title') { title } + yield
+      end
+    end
+  end
+
+  ##
+  # Same as {#block_with_title}, but uses +captioned_title+ as a title.
+  #
+  # @param klass [Array<String>, String] the style classes (default: [])
+  # @yieldreturn [String] HTML fragment to be wrapped.
+  # @return [String] HTML
+  #
+  def block_with_captitle(klass = [], &block)
+    block_with_title klass, captioned_title, &block
+  end
+
+  ##
+  # Delimite the given equation as a STEM of the specified type.
+  #
+  # @param equation [String] the equation to delimite.
+  # @param type [#to_sym] the type of the STEM renderer (latexmath, or asciimath).
+  # @return [String] the delimited equation.
+  #
+  def delimit_stem(equation, type)
+    if is_a? ::Asciidoctor::Block
+      open, close = ::Asciidoctor::BLOCK_MATH_DELIMITERS[type.to_sym]
+    else
+      open, close = ::Asciidoctor::INLINE_MATH_DELIMITERS[type.to_sym]
+    end
+
+    unless equation.start_with?(open) && equation.end_with?(close)
+      equation = [open, equation, close].join
+    end
+    equation
+  end
+
+  ##
+  # Formats the given hash as CSS declarations for an inline style.
+  #
+  # @example
+  #   style_value(text_align: 'right', float: 'left')
+  #   => "text-align: right; float: left;"
+  #
+  #   style_value(text_align: nil, float: 'left')
+  #   => "float: left;"
+  #
+  #   style_value(width: [90, '%'], height: '50px')
+  #   => "width: 90%; height: 50px;"
+  #
+  #   style_value(width: ['120px', 'px'])
+  #   => "width: 90px;"
+  #
+  #   style_value(width: [nil, 'px'])
+  #   => nil
+  #
+  # @param declarations [Hash]
+  # @return [String, nil]
+  #
+  def style_value(declarations)
+    decls = []
+
+    declarations.each do |prop, value|
+      next if value.nil?
+
+      if value.is_a? Array
+        value, unit = value
+        next if value.nil?
+        value = value.to_s + unit unless value.end_with? unit
+      end
+      prop = prop.to_s.gsub('_', '-')
+      decls << "#{prop}: #{value}"
+    end
+
     decls.empty? ? nil : decls.join('; ') + ';'
+  end
+
+  def urlize(*segments)
+    path = segments * '/'
+    if path.start_with? '//'
+      @_uri_scheme ||= document.attr 'asset-uri-scheme', 'https'
+      path = "#{@_uri_scheme}:#{path}" unless @_uri_scheme.empty?
+    end
+    normalize_web_path path
+  end
+
+
+  ##
+  # @param index [Integer] the footnote's index.
+  # @return [String] footnote id to be used in a link.
+  def footnote_id(index = (attr :index))
+    "_footnote_#{index}"
+  end
+
+  ##
+  # @param index (see #footnote_id)
+  # @return [String] footnoteref id to be used in a link.
+  def footnoteref_id(index = (attr :index))
+    "_footnoteref_#{index}"
+  end
+
+  def icons?
+    document.attr? :icons
+  end
+
+  def icons_font?
+    document.attr? :icons, 'font'
+  end
+
+  def nowrap?
+    'nowrap' if !document.attr?(:prewrap) || option?('nowrap')
+  end
+
+  ##
+  # Returns corrected section level.
+  #
+  # @param sec [Asciidoctor::Section] the section node (default: self).
+  # @return [Integer]
+  #
+  def section_level(sec = self)
+    @_section_level ||= (sec.level == 0 && sec.special) ? 1 : sec.level
+  end
+
+  ##
+  # Returns the captioned section's title, optionally numbered.
+  #
+  # @param sec [Asciidoctor::Section] the section node (default: self).
+  # @return [String]
+  #
+  def section_title(sec = self)
+    sectnumlevels = document.attr(:sectnumlevels, DEFAULT_SECTNUMLEVELS).to_i
+
+    if sec.numbered && !sec.caption && sec.level <= sectnumlevels
+      [sec.sectnum, sec.captioned_title].join(' ')
+    else
+      sec.captioned_title
+    end
+  end
+
+  #--------------------------------------------------------
+  # block_listing
+  #
+
+  ##
+  # @return [String] a canonical name of the source-highlighter to be used as
+  #         a style class.
+  def highlighter
+    @_highlighter ||=
+      case (highlighter = document.attr 'source-highlighter')
+      when 'coderay'; 'CodeRay'
+      when 'highlight.js'; 'highlightjs'
+      when 'prettify'; 'prettyprint'
+      else highlighter
+      end
+  end
+
+  def source_lang
+    attr :language, nil, false
+  end
+
+  #--------------------------------------------------------
+  # block_open
+  #
+
+  ##
+  # Returns +true+ if an abstract block is allowed in this document type,
+  # otherwise prints warning and returns +false+.
+  def abstract_allowed?
+    if result = (parent == document && document.doctype == 'book')
+      puts 'asciidoctor: WARNING: abstract block cannot be used in a document
+without a title when doctype is book. Excluding block content.'
+    end
+    !result
+  end
+
+  ##
+  # Returns +true+ if a partintro block is allowed in this context, otherwise
+  # prints warning and returns +false+.
+  def partintro_allowed?
+    if result = (level != 0 || parent.context != :section || document.doctype != 'book')
+      puts "asciidoctor: ERROR: partintro block can only be used when doctype
+is book and it's a child of a book part. Excluding block content."
+    end
+    !result
+  end
+
+  #--------------------------------------------------------
+  # block_video
+  #
+
+  # @return [Boolean] +true+ if the video should be embedded in an iframe.
+  def video_iframe?
+    ['vimeo', 'youtube'].include?(attr :poster)
+  end
+
+  def video_uri
+    case (attr :poster, '').to_sym
+    when :vimeo
+      params = {
+        :autoplay => (1 if option? 'autoplay'),
+        :loop     => (1 if option? 'loop')
+      }
+      start_anchor = "#at=#{attr :start}" if attr? :start
+      "//player.vimeo.com/video/#{attr :target}#{start_anchor}#{url_query params}"
+    when :youtube
+      params = {
+        :rel      => 0,
+        :start    => (attr :start),
+        :end      => (attr :end),
+        :autoplay => (1 if option? 'autoplay'),
+        :loop     => (1 if option? 'loop'),
+        :controls => (0 if option? 'nocontrols')
+      }
+      "//www.youtube.com/embed/#{attr :target}#{url_query params}"
+    else
+      media_uri(attr :target)
+    end
+  end
+
+  # Formats URL query parameters.
+  def url_query(params)
+    str = params.map { |k, v|
+      next if v.nil? || v.to_s.empty?
+      [k, v] * '='
+    }.compact.join('&amp;')
+
+    str.prepend('?') unless str.empty?
+  end
+
+  #--------------------------------------------------------
+  # document
+  #
+
+  ##
+  # Returns HTML meta tag if the given +content+ is not +nil+.
+  #
+  # @param name [#to_s] the name for the metadata.
+  # @param content [#to_s, nil] the value of the metadata, or +nil+.
+  # @return [String, nil] the meta tag, or +nil+ if the +content+ is +nil+.
+  #
+  def html_meta_if(name, content)
+    %(<meta name="#{name}" content="#{content}">) if content
+  end
+
+  # Returns formatted style/link and script tags for header.
+  def styles_and_scripts
+    scripts = []
+    styles = []
+    tags = []
+
+    stylesheet = attr :stylesheet
+    stylesdir = attr :stylesdir, ''
+    default_style = ::Asciidoctor::DEFAULT_STYLESHEET_KEYS.include? stylesheet
+    linkcss = (attr? :linkcss) || safe >= ::Asciidoctor::SafeMode::SECURE
+    ss = ::Asciidoctor::Stylesheets.instance
+
+    if linkcss
+      path = default_style ? ::Asciidoctor::DEFAULT_STYLESHEET_NAME : stylesheet
+      styles << { href: [stylesdir, path] }
+    elsif default_style
+      styles << { text: ss.primary_stylesheet_data }
+    else
+      styles << { text: read_asset(normalize_system_path(stylesheet, stylesdir), true) }
+    end
+
+    if attr? :icons, 'font'
+      if attr? 'iconfont-remote'
+        styles << { href: (attr 'iconfont-cdn', FONT_AWESOME_URI) }
+      else
+        styles << { href: [stylesdir, "#{attr 'iconfont-name', 'font-awesome'}.css"] }
+      end
+    end
+
+    if attr? 'stem'
+      scripts << { src: MATHJAX_JS_URI }
+      scripts << { type: 'text/x-mathjax-config', text: "MathJax.Hub.Config(#{MATHJAX_CONFIG});" }
+    end
+
+    case attr 'source-highlighter'
+    when 'coderay'
+      if (attr 'coderay-css', 'class') == 'class'
+        if linkcss
+          styles << { href: [stylesdir, ss.coderay_stylesheet_name] }
+        else
+          styles << { text: ss.coderay_stylesheet_data }
+        end
+      end
+
+    when 'pygments'
+      if (attr 'pygments-css', 'class') == 'class'
+        if linkcss
+          styles << { href: [stylesdir, ss.pygments_stylesheet_name(attr 'pygments-style')] }
+        else
+          styles << { text: ss.pygments_stylesheet_data(attr 'pygments-style') }
+        end
+      end
+
+    when 'highlightjs'
+      hjs_base = attr :highlightjsdir, HIGHLIGHTJS_BASE_URI
+      hjs_theme = attr 'highlightjs-theme', DEFAULT_HIGHLIGHTJS_THEME
+
+      scripts << { src: [hjs_base, 'highlight.min.js'] }
+      scripts << { src: [hjs_base, 'lang/common.min.js'] }
+      scripts << { text: 'hljs.initHighlightingOnLoad()' }
+      styles  << { href: [hjs_base, "styles/#{hjs_theme}.min.css"] }
+
+    when 'prettify'
+      prettify_base = attr :prettifydir, PRETTIFY_BASE_URI
+      prettify_theme = attr 'prettify-theme', DEFAULT_PRETTIFY_THEME
+
+      scripts << { src: [prettify_base, 'prettify.min.js'] }
+      scripts << { text: 'document.addEventListener("DOMContentLoaded", prettyPrint)' }
+      styles  << { href: [prettify_base, "#{prettify_theme}.min.css"] }
+    end
+
+    styles.each do |item|
+      if item.key?(:text)
+        tags << html_tag(:style) { item[:text] }
+      else
+        tags << html_tag(:link, rel: 'stylesheet', href: urlize(*item[:href]))
+      end
+    end
+
+    scripts.each do |item|
+      if item.key? :text
+        tags << html_tag(:script, type: item[:type]) { item[:text] }
+      else
+        tags << html_tag(:script, type: item[:type], src: urlize(*item[:src]))
+      end
+    end
+
+    tags.join "\n"
+  end
+
+  #--------------------------------------------------------
+  # inline_anchor
+  #
+
+  # @return [String, nil] text of the xref anchor, or +nil+ if not found.
+  def xref_text
+    str = text || document.references[:ids][attr :refid || target]
+    str.tr_s("\n", ' ') if str
+  end
+
+  #--------------------------------------------------------
+  # inline_image
+  #
+
+  # @return [Array] style classes for a Font Awesome icon.
+  def icon_fa_classes
+    [ "fa fa-#{target}",
+      ("fa-#{attr :size}" if attr? :size),
+      ("fa-rotate-#{attr :rotate}" if attr? :rotate),
+      ("fa-flip-#{attr :flip}" if attr? :flip)
+    ].compact
   end
 end

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -302,19 +302,6 @@ module Slim::Helpers
   # block_listing
   #
 
-  ##
-  # @return [String] a canonical name of the source-highlighter to be used as
-  #         a style class.
-  def highlighter
-    @_highlighter ||=
-      case (highlighter = document.attr 'source-highlighter')
-      when 'coderay'; 'CodeRay'
-      when 'highlight.js'; 'highlightjs'
-      when 'prettify'; 'prettyprint'
-      else highlighter
-      end
-  end
-
   def source_lang
     attr :language, nil, false
   end

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -346,6 +346,18 @@ is book and it's a child of a book part. Excluding block content."
   end
 
   #--------------------------------------------------------
+  # block_table
+  #
+
+  def autowidth?
+    option? :autowidth
+  end
+
+  def spread?
+    'spread' if !(option? 'autowidth') && (attr :tablepcwidth) == 100
+  end
+
+  #--------------------------------------------------------
   # block_video
   #
 

--- a/slim/html5/inline_anchor.html.slim
+++ b/slim/html5/inline_anchor.html.slim
@@ -1,11 +1,10 @@
-- case @type
+- case type
 - when :xref
-  - refid = (attr :refid) || @target
-  a href=@target =(@text || @document.references[:ids].fetch(refid, "[#{refid}]")).tr_s("\n", ' ')
+  a href=target =(xref_text || "[#{attr :refid}]")
 - when :ref
-  a id=@target
+  a id=target
 - when :bibref
-  a id=@target
-  |[#{@target}]
+  a id=target
+  | [#{@target}]
 - else
-  a id=@id class=role href=@target target=(attr :window) title=(attr :title) =@text
+  a id=id class=role href=target target=(attr :window) title=(attr :title) =text

--- a/slim/html5/inline_break.html.slim
+++ b/slim/html5/inline_break.html.slim
@@ -1,2 +1,2 @@
-=@text
+=text
 br

--- a/slim/html5/inline_button.html.slim
+++ b/slim/html5/inline_button.html.slim
@@ -1,1 +1,1 @@
-b.button=@text
+b.button =text

--- a/slim/html5/inline_callout.html.slim
+++ b/slim/html5/inline_callout.html.slim
@@ -1,7 +1,7 @@
-- if @document.attr? :icons, 'font'
-  i.conum data-value=@text
-  b="(#{@text})"
-- elsif @document.attr? :icons
-  img src=icon_uri("callouts/#{@text}") alt=@text
+- if icons_font?
+  i.conum data-value=text
+  b ="(#{text})"
+- elsif icons?
+  img src=icon_uri("callouts/#{text}") alt=text
 - else
-  b.conum ="(#{@text})"
+  b.conum ="(#{text})"

--- a/slim/html5/inline_footnote.html.slim
+++ b/slim/html5/inline_footnote.html.slim
@@ -1,9 +1,11 @@
-- if (index = attr :index)
-  - if @type == :xref
+- if type == :xref
+  - if attr :index
     span.footnoteref
-      | [<a class="footnote" href="#_footnote_#{index}" title="View footnote.">#{index}</a>]
+      = surround '[', ']'
+        a.footnote href="##{footnote_id}" title="View footnote." =(attr :index)
   - else
-    span.footnote id=("_footnote_#{@id}" if @id)
-      | [<a id="_footnoteref_#{index}" class="footnote" href="#_footnote_#{index}" title="View footnote.">#{index}</a>]
-- elsif @type == :xref
-  span.footnoteref.red title="Unresolved footnote reference." [#{text}]
+    span.footnoteref.red title="Unresolved footnote reference." [#{text}]
+- else
+  span.footnote id=(footnote_id id if id)
+    = surround '[', ']'
+      a.footnote id=footnoteref_id href="##{footnote_id}" title="View footnote." =(attr :index)

--- a/slim/html5/inline_image.html.slim
+++ b/slim/html5/inline_image.html.slim
@@ -1,24 +1,9 @@
-span class=[@type,role] style=Helpers.style_value(float: (attr :float))
-  - if @type == 'icon' && (@document.attr? :icons, 'font')
-    - style_class = ["fa fa-#{@target}"]
-    - style_class << "fa-#{attr :size}" if attr? :size
-    - style_class << "fa-rotate-#{attr :rotate}" if attr? :rotate
-    - style_class << "fa-flip-#{attr :flip}" if attr? :flip
-    - if attr? :link
-      a.image href=(attr :link) target=(attr :window)
-        i class=style_class title=(attr :title)
+span class=[type, role] style=style_value(float: (attr :float))
+  = html_tag_if (attr? :link), :a, {:class=>'image', :href=>(attr :link), :target=>(attr :window)}
+    - if type == 'icon' && icons_font?
+      i class=icon_fa_classes title=(attr :title)
+    - elsif type == 'icon' && !icons?
+      | [#{attr :alt}]
     - else
-      i class=style_class title=(attr :title)
-  - elsif @type == 'icon' && !(@document.attr? :icons)
-    - if attr? :link
-      a.image href=(attr :link) target=(attr :window)
-        |[#{attr :alt}]
-    - else
-      |[#{attr :alt}]
-  - else
-    - src = (@type == 'icon' ? (icon_uri @target) : (image_uri @target))
-    - if attr? :link
-      a.image href=(attr :link) target=(attr :window)
-        img src=src alt=(attr :alt) width=(attr :width) height=(attr :height) title=(attr :title)
-    - else
+      - src = (type == 'icon' ? (icon_uri target) : (image_uri target))
       img src=src alt=(attr :alt) width=(attr :width) height=(attr :height) title=(attr :title)

--- a/slim/html5/inline_indexterm.html.slim
+++ b/slim/html5/inline_indexterm.html.slim
@@ -1,2 +1,2 @@
-- if @type == :visible
-  =@text
+- if type == :visible
+  =text

--- a/slim/html5/inline_kbd.html.slim
+++ b/slim/html5/inline_kbd.html.slim
@@ -1,8 +1,7 @@
 - if (keys = attr 'keys').size == 1
-  kbd=keys.first
+  kbd =keys.first
 - else
   kbd.keyseq
     - keys.each_with_index do |key, idx|
-      - unless idx.zero?
-        |+
-      kbd=key
+      ="+" unless idx.zero?
+      kbd =key

--- a/slim/html5/inline_menu.html.slim
+++ b/slim/html5/inline_menu.html.slim
@@ -1,15 +1,10 @@
-- menu = attr 'menu'
-- menuitem = attr 'menuitem'
-- if !(submenus = attr 'submenus').empty?
+- if attr :menuitem
   span.menuseq
-    span.menu=menu
+    span.menu =(attr :menu)
     '&#160;&#9656;
-    ='submenus.map {|submenu| %(<span class="submenu">#{submenu}</span>&#160;&#9656; ) }.join.chop
-    span.menuitem=menuitem
-- elsif !menuitem.nil?
-  span.menuseq
-    span.menu=menu
-    '&#160;&#9656;
-    span.menuitem=menuitem
+    - (attr 'submenus').each do |submenu|
+      span.submenu =submenu
+      '&#160;&#9656;
+    span.menuitem =(attr :menuitem)
 - else
-  span.menu=menu
+  span.menu =(attr :menu)

--- a/slim/html5/inline_quoted.html.slim
+++ b/slim/html5/inline_quoted.html.slim
@@ -1,24 +1,26 @@
-- unless @id.nil?
-  a id=@id
-- case @type
+- unless id.nil?
+  a id=id
+- case type
 - when :emphasis
-  em class=role =@text
+  em class=role =text
 - when :strong
-  strong class=role =@text
+  strong class=role =text
 - when :monospaced
-  code class=role =@text
+  code class=role =text
 - when :superscript
-  sup class=role =@text
+  sup class=role =text
 - when :subscript
-  sub class=role =@text
+  sub class=role =text
 - when :mark
-  mark class=role =@text
+  mark class=role =text
 - when :double
-  =role? ? %(<span class="#{role}">&#8220;#{@text}&#8221;</span>) : %(&#8220;#{@text}&#8221;)
+  = html_tag_if role?, :span, :class=>role
+    | &#8220;#{text}&#8221;
 - when :single
-  =role? ? %(<span class="#{role}">&#8216;#{@text}&#8217;</span>) : %(&#8216;#{@text}&#8217;)
+  = html_tag_if role?, :span, :class=>role
+    | &#8216;#{text}&#8217;
 - when :asciimath, :latexmath
-  - open, close = Asciidoctor::INLINE_MATH_DELIMITERS[@type]
-  |#{open}#{@text}#{close}
+  =delimit_stem text, type
 - else
-  =role? ? %(<span class="#{role}">#{@text}</span>) : @text
+  = html_tag_if role?, :span, :class=>role
+    =text

--- a/slim/html5/section.html.slim
+++ b/slim/html5/section.html.slim
@@ -1,21 +1,14 @@
-- slevel = @level == 0 && @special ? 1 : @level
-- anchor = nil
-- link = nil
-- if @id
-  - if @document.attr? :sectanchors
-    - anchor = %(<a class="anchor" href="##{@id}"></a>)
-    - link = nil
-  - elsif @document.attr? :sectlinks
-    - anchor = nil
-    - link = %(<a class="link" href="##{@id}">)
-- if slevel == 0
-  h1 id=@id class='sect0' =%(#{anchor}#{link}#{title}#{link && '</a>'})
-  =content
-- else
-  div class=["sect#{slevel}",role]
-    - snum = @numbered && @caption.nil? && slevel <= (@document.attr :sectnumlevels, 3).to_i ? %(#{sectnum} ) : nil
-    *{:tag=>"h#{slevel + 1}", :id=>@id} =%(#{anchor}#{link}#{snum}#{captioned_title}#{link && '</a>'})
-    - if slevel == 1
-      .sectionbody=content
+- sect0 = section_level == 0
+= html_tag_if !sect0, :div, :class=>["sect#{section_level}", role]
+  *{:tag=>"h#{section_level + 1}", :id=>id, :class=>('sect0' if sect0)}
+    - if id && (document.attr? :sectanchors)
+      a.anchor href="##{id}"
+      =section_title
+    - elsif id && (document.attr? :sectlinks)
+      a.link href="##{id}" =section_title
     - else
-      =content
+      =section_title
+  - if section_level == 1
+    .sectionbody =content
+  - else
+    =content

--- a/test/examples/asciidoc-html/README
+++ b/test/examples/asciidoc-html/README
@@ -1,0 +1,1 @@
+This directory contains additional testing examples for HTML-based backends.

--- a/test/examples/asciidoc-html/block_admonition.adoc
+++ b/test/examples/asciidoc-html/block_admonition.adoc
@@ -1,7 +1,7 @@
-// .icons-image
+// .icons_image
 :icons:
 WARNING: Watch out for dragons!
 
-// .icons-font
+// .icons_font
 :icons: font
 WARNING: Watch out for dragons!

--- a/test/examples/asciidoc-html/block_admonition.adoc
+++ b/test/examples/asciidoc-html/block_admonition.adoc
@@ -1,0 +1,7 @@
+// .icons-image
+:icons:
+WARNING: Watch out for dragons!
+
+// .icons-font
+:icons: font
+WARNING: Watch out for dragons!

--- a/test/examples/asciidoc-html/block_colist.adoc
+++ b/test/examples/asciidoc-html/block_colist.adoc
@@ -1,4 +1,4 @@
-// .icons-image
+// .icons_image
 :icons:
 [source, ruby]
 ----
@@ -12,7 +12,7 @@ end
 <2> URL mapping
 <3> Content for response
 
-// .icons-font
+// .icons_font
 :icons: font
 [source, ruby]
 ----

--- a/test/examples/asciidoc-html/block_colist.adoc
+++ b/test/examples/asciidoc-html/block_colist.adoc
@@ -1,0 +1,27 @@
+// .icons-image
+:icons:
+[source, ruby]
+----
+require 'sinatra' // <1>
+
+get '/hi' do  # <2>
+  "Hello World!" ;; <3>
+end
+----
+<1> Library import
+<2> URL mapping
+<3> Content for response
+
+// .icons-font
+:icons: font
+[source, ruby]
+----
+require 'sinatra' // <1>
+
+get '/hi' do  # <2>
+  "Hello World!" ;; <3>
+end
+----
+<1> Library import
+<2> URL mapping
+<3> Content for response

--- a/test/examples/asciidoc-html/block_listing.adoc
+++ b/test/examples/asciidoc-html/block_listing.adoc
@@ -1,0 +1,40 @@
+// .source-highlighter-coderay
+:source-highlighter: coderay
+
+[source, ruby]
+----
+5.times do
+  print "Odelay!"
+end
+----
+
+// .source-highlighter-pygments
+:source-highlighter: pygments
+
+[source, ruby]
+----
+5.times do
+  print "Odelay!"
+end
+----
+
+// .source-highlighter-prettify
+:source-highlighter: prettify
+
+[source, ruby]
+----
+5.times do
+  print "Odelay!"
+end
+----
+
+// .source-highlighter-html-pipeline
+// nowrap should be ignored
+:source-highlighter: html-pipeline
+
+[source, ruby, options="nowrap"]
+----
+5.times do
+  print "Odelay!"
+end
+----

--- a/test/examples/asciidoc-html/block_listing.adoc
+++ b/test/examples/asciidoc-html/block_listing.adoc
@@ -1,4 +1,4 @@
-// .source-highlighter-coderay
+// .source_highlighter_coderay
 :source-highlighter: coderay
 
 [source, ruby]
@@ -8,7 +8,7 @@
 end
 ----
 
-// .source-highlighter-pygments
+// .source_highlighter_pygments
 :source-highlighter: pygments
 
 [source, ruby]
@@ -18,7 +18,7 @@ end
 end
 ----
 
-// .source-highlighter-prettify
+// .source_highlighter_prettify
 :source-highlighter: prettify
 
 [source, ruby]
@@ -28,7 +28,7 @@ end
 end
 ----
 
-// .source-highlighter-html-pipeline
+// .source_highlighter_html_pipeline
 // nowrap should be ignored
 :source-highlighter: html-pipeline
 

--- a/test/examples/asciidoc-html/block_ulist.adoc
+++ b/test/examples/asciidoc-html/block_ulist.adoc
@@ -1,11 +1,11 @@
-// .checklist-interactive
+// .checklist_interactive
 [options="interactive"]
 - [*] checked
 - [x] also checked
 - [ ] not checked
 -     normal list item
 
-// .checklist-icons-font
+// .checklist_icons_font
 :icons: font
 - [*] checked
 - [x] also checked

--- a/test/examples/asciidoc-html/block_ulist.adoc
+++ b/test/examples/asciidoc-html/block_ulist.adoc
@@ -1,0 +1,6 @@
+// .checklist-interactive
+[options="interactive"]
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item

--- a/test/examples/asciidoc-html/block_ulist.adoc
+++ b/test/examples/asciidoc-html/block_ulist.adoc
@@ -4,3 +4,10 @@
 - [x] also checked
 - [ ] not checked
 -     normal list item
+
+// .checklist-icons-font
+:icons: font
+- [*] checked
+- [x] also checked
+- [ ] not checked
+-     normal list item

--- a/test/examples/asciidoc-html/block_video.adoc
+++ b/test/examples/asciidoc-html/block_video.adoc
@@ -1,17 +1,17 @@
 // .youtube
 video::rPQoq7ThGAU[youtube]
 
-// .youtube-iframe-params
+// .youtube_iframe_params
 video::rPQoq7ThGAU[youtube, width=640, height=480, options="nofullscreen"]
 
-// .youtube-url-params
+// .youtube_url_params
 video::rPQoq7ThGAU[youtube, start=60, end=140, options="autoplay, loop, nocontrol"]
 
 // .vimeo
 video::32255377[vimeo]
 
-// .vimeo-iframe-params
+// .vimeo_iframe_params
 video::32255377[vimeo, width=640, height=480, options="nofullscreen"]
 
-// .vimeo-url-params
+// .vimeo_url_params
 video::32255377[vimeo, start=60, options="autoplay, loop"]

--- a/test/examples/asciidoc-html/block_video.adoc
+++ b/test/examples/asciidoc-html/block_video.adoc
@@ -1,0 +1,17 @@
+// .youtube
+video::rPQoq7ThGAU[youtube]
+
+// .youtube-iframe-params
+video::rPQoq7ThGAU[youtube, width=640, height=480, options="nofullscreen"]
+
+// .youtube-url-params
+video::rPQoq7ThGAU[youtube, start=60, end=140, options="autoplay, loop, nocontrol"]
+
+// .vimeo
+video::32255377[vimeo]
+
+// .vimeo-iframe-params
+video::32255377[vimeo, width=640, height=480, options="nofullscreen"]
+
+// .vimeo-url-params
+video::32255377[vimeo, start=60, options="autoplay, loop"]

--- a/test/examples/asciidoc-html/inline_callout.adoc
+++ b/test/examples/asciidoc-html/inline_callout.adoc
@@ -1,0 +1,13 @@
+// .icons-image
+:icons:
+[source]
+----
+"Hello world!" // <1>
+----
+
+// .icons-font
+:icons: font
+[source]
+----
+"Hello world!" // <1>
+----

--- a/test/examples/asciidoc-html/inline_callout.adoc
+++ b/test/examples/asciidoc-html/inline_callout.adoc
@@ -1,11 +1,11 @@
-// .icons-image
+// .icons_image
 :icons:
 [source]
 ----
 "Hello world!" // <1>
 ----
 
-// .icons-font
+// .icons_font
 :icons: font
 [source]
 ----

--- a/test/examples/asciidoc-html/inline_image.adoc
+++ b/test/examples/asciidoc-html/inline_image.adoc
@@ -1,19 +1,19 @@
-// .icon-font
+// .icon_font
 :icons: font
 icon:heart[]
 
-// .icon-font-with-title
+// .icon_font_with_title
 :icons: font
 icon:heart[title="I <3 Asciidoctor"]
 
-// .icon-font-with-size
+// .icon_font_with_size
 :icons: font
 icon:shield[2x]
 
-// .icon-font-with-rotate
+// .icon_font_with_rotate
 :icons: font
 icon:shield[rotate=90]
 
-// .icon-font-with-flip
+// .icon_font_with_flip
 :icons: font
 icon:shield[flip=vertical]

--- a/test/examples/asciidoc-html/inline_image.adoc
+++ b/test/examples/asciidoc-html/inline_image.adoc
@@ -1,0 +1,19 @@
+// .icon-font
+:icons: font
+icon:heart[]
+
+// .icon-font-with-title
+:icons: font
+icon:heart[title="I <3 Asciidoctor"]
+
+// .icon-font-with-size
+:icons: font
+icon:shield[2x]
+
+// .icon-font-with-rotate
+:icons: font
+icon:shield[rotate=90]
+
+// .icon-font-with-flip
+:icons: font
+icon:shield[flip=vertical]

--- a/test/examples/html5/block_admonition.html
+++ b/test/examples/html5/block_admonition.html
@@ -10,7 +10,7 @@
   </table>
 </div>
 
-<!-- .basic-multiline -->
+<!-- .basic_multiline -->
 <div class="admonitionblock note">
   <table>
     <tr>
@@ -43,7 +43,7 @@ at the beginning of the paragraph.
   </table>
 </div>
 
-<!-- .block-with-title -->
+<!-- .block_with_title -->
 <div class="admonitionblock important">
   <table>
     <tr>
@@ -60,7 +60,7 @@ at the beginning of the paragraph.
   </table>
 </div>
 
-<!-- .block-with-id-and-role -->
+<!-- .block_with_id_and_role -->
 <div class="admonitionblock important member" id="werewolve">
   <table>
     <tr>
@@ -76,7 +76,7 @@ at the beginning of the paragraph.
   </table>
 </div>
 
-<!-- .icons-image -->
+<!-- .icons_image -->
 <div class="admonitionblock warning">
   <table>
     <tr>
@@ -88,7 +88,7 @@ at the beginning of the paragraph.
   </table>
 </div>
 
-<!-- .icons-font -->
+<!-- .icons_font -->
 <div class="admonitionblock warning">
   <table>
     <tr>

--- a/test/examples/html5/block_audio.html
+++ b/test/examples/html5/block_audio.html
@@ -5,14 +5,14 @@
   </div>
 </div>
 
-<!-- .with-all-options -->
+<!-- .with_all_options -->
 <div class="audioblock">
   <div class="content">
     <audio autoplay loop src="ocean_waves.mp3">Your browser does not support the audio tag.</audio>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="audioblock">
   <div class="title">Waves!</div>
   <div class="content">
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="audioblock wave" id="ocean">
   <div class="content">
     <audio controls src="ocean_waves.mp3">Your browser does not support the audio tag.</audio>

--- a/test/examples/html5/block_colist.html
+++ b/test/examples/html5/block_colist.html
@@ -15,7 +15,7 @@
   </ol>
 </div>
 
-<!-- .with-title
+<!-- .with_title
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">
@@ -33,7 +33,7 @@
   </ol>
 </div>
 
-<!-- .with-id-and-role
+<!-- .with_id_and_role
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic sinatra" id="call">
@@ -50,7 +50,7 @@
   </ol>
 </div>
 
-<!-- .icons-image
+<!-- .icons_image
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">
@@ -70,7 +70,7 @@
   </table>
 </div>
 
-<!-- .icons-font
+<!-- .icons_font
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">

--- a/test/examples/html5/block_colist.html
+++ b/test/examples/html5/block_colist.html
@@ -1,5 +1,4 @@
 <!-- .basic
-// callouts inside a listing block are tested in inline_callout
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">
@@ -17,7 +16,6 @@
 </div>
 
 <!-- .with-title
-// callouts inside a listing block are tested in inline_callout
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">
@@ -36,7 +34,6 @@
 </div>
 
 <!-- .with-id-and-role
-// callouts inside a listing block are tested in inline_callout
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic sinatra" id="call">
@@ -54,7 +51,6 @@
 </div>
 
 <!-- .icons-image
-// callouts inside a listing block are tested in inline_callout
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">
@@ -75,7 +71,6 @@
 </div>
 
 <!-- .icons-font
-// callouts inside a listing block are tested in inline_callout
 :exclude: ./div[@class="listingblock"]
 -->
 <div class="colist arabic">

--- a/test/examples/html5/block_dlist.html
+++ b/test/examples/html5/block_dlist.html
@@ -13,7 +13,7 @@ ebooks, slideshows, web pages, man pages and blogs.</p>
   </dl>
 </div>
 
-<!-- .basic-block -->
+<!-- .basic_block -->
 <div class="dlist">
   <dl>
     <dt class="hdlist1">About</dt>
@@ -40,14 +40,14 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </dl>
 </div>
 
-<!-- .basic-missing-description -->
+<!-- .basic_missing_description -->
 <div class="dlist">
   <dl>
     <dt class="hdlist1">Definition without a description</dt>
   </dl>
 </div>
 
-<!-- .basic-with-title -->
+<!-- .basic_with_title -->
 <div class="dlist">
   <div class="title">Asciidoctor</div>
   <dl>
@@ -58,7 +58,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </dl>
 </div>
 
-<!-- .basic-with-id-and-role -->
+<!-- .basic_with_id_and_role -->
 <div class="dlist open" id="licenses">
   <dl>
     <dt class="hdlist1">License</dt>
@@ -82,7 +82,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </ol>
 </div>
 
-<!-- .qanda-block -->
+<!-- .qanda_block -->
 <div class="qlist qanda">
   <ol>
     <li>
@@ -109,7 +109,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </ol>
 </div>
 
-<!-- .qanda-missing-answer -->
+<!-- .qanda_missing_answer -->
 <div class="qlist qanda">
   <ol>
     <li>
@@ -118,7 +118,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </ol>
 </div>
 
-<!-- .qanda-with-title -->
+<!-- .qanda_with_title -->
 <div class="qlist qanda">
   <div class="title">The most important questions</div>
   <ol>
@@ -129,7 +129,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </ol>
 </div>
 
-<!-- .qanda-with-id-and-role -->
+<!-- .qanda_with_id_and_role -->
 <div class="qlist qanda galaxy" id="faq">
   <ol>
     <li>
@@ -157,7 +157,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </table>
 </div>
 
-<!-- .horizontal-with-dimensions -->
+<!-- .horizontal_with_dimensions -->
 <div class="hdlist">
   <table>
     <colgroup>
@@ -179,7 +179,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </table>
 </div>
 
-<!-- .horizontal-with-title -->
+<!-- .horizontal_with_title -->
 <div class="hdlist">
   <div class="title">Computer terminology for noobs</div>
   <table>
@@ -198,7 +198,7 @@ from many other individuals in Asciidoctor’s awesome community.</p>
   </table>
 </div>
 
-<!-- .horizontal-with-id-and-role -->
+<!-- .horizontal_with_id_and_role -->
 <div class="hdlist terms" id="computer">
   <table>
     <tr>

--- a/test/examples/html5/block_example.html
+++ b/test/examples/html5/block_example.html
@@ -8,7 +8,7 @@ incididunt ut labore et dolore magna aliqua.</p>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="exampleblock">
   <div class="title">Example 1. Sample document</div>
   <div class="content">
@@ -22,7 +22,7 @@ incididunt ut labore et dolore magna aliqua.</p>
   </div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="exampleblock ipsum" id="lorem">
   <div class="content">
     <div class="paragraph">

--- a/test/examples/html5/block_floating_title.html
+++ b/test/examples/html5/block_floating_title.html
@@ -13,8 +13,8 @@
 <!-- .level5 -->
 <h6 class="discrete" id="_discrete_title_level_5">Discrete Title Level 5</h6>
 
-<!-- .with-custom-id -->
+<!-- .with_custom_id -->
 <h2 class="discrete" id="flying">Discrete Title Level 1</h2>
 
-<!-- .with-roles -->
+<!-- .with_roles -->
 <h3 class="discrete flying circus" id="_discrete_title_level_2">Discrete Title Level 2</h3>

--- a/test/examples/html5/block_image.html
+++ b/test/examples/html5/block_image.html
@@ -5,35 +5,35 @@
   </div>
 </div>
 
-<!-- .with-alt-text -->
+<!-- .with_alt_text -->
 <div class="imageblock">
   <div class="content">
     <img alt="Shining sun" src="sunset.jpg">
   </div>
 </div>
 
-<!-- .with-align -->
+<!-- .with_align -->
 <div class="imageblock" style="text-align: center">
   <div class="content">
     <img alt="sunset" src="sunset.jpg">
   </div>
 </div>
 
-<!-- .with-float -->
+<!-- .with_float -->
 <div class="imageblock" style="float: right">
   <div class="content">
     <img alt="sunset" src="sunset.jpg">
   </div>
 </div>
 
-<!-- .with-dimensions -->
+<!-- .with_dimensions -->
 <div class="imageblock">
   <div class="content">
     <img alt="Shining sun" height="200" src="sunset.jpg" width="300">
   </div>
 </div>
 
-<!-- .with-link -->
+<!-- .with_link -->
 <div class="imageblock">
   <div class="content">
     <a class="image" href="http://www.flickr.com/photos/javh/5448336655">
@@ -42,7 +42,7 @@
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="imageblock">
   <div class="content">
     <img alt="sunset" src="sunset.jpg">
@@ -50,14 +50,14 @@
   <div class="title">Figure 1. A mountain sunset</div>
 </div>
 
-<!-- .with-id -->
+<!-- .with_id -->
 <div class="imageblock" id="img-sunset">
   <div class="content">
     <img alt="sunset" src="sunset.jpg">
   </div>
 </div>
 
-<!-- .with-roles -->
+<!-- .with_roles -->
 <div class="imageblock right text-center">
   <div class="content">
     <img alt="sunset" src="sunset.jpg">

--- a/test/examples/html5/block_listing.html
+++ b/test/examples/html5/block_listing.html
@@ -7,7 +7,7 @@ echo "Hello, $name!"</pre>
   </div>
 </div>
 
-<!-- .basic-with-title -->
+<!-- .basic_with_title -->
 <div class="listingblock">
   <div class="title">Reading user input</div>
   <div class="content">
@@ -17,14 +17,14 @@ echo "Hello, $name!"</pre>
   </div>
 </div>
 
-<!-- .basic-nowrap -->
+<!-- .basic_nowrap -->
 <div class="listingblock">
   <div class="content">
     <pre class="nowrap">ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"</pre>
   </div>
 </div>
 
-<!-- .basic-with-id-and-role -->
+<!-- .basic_with_id_and_role -->
 <div class="listingblock example" id="code">
   <div class="content">
     <pre>echo -n "Please enter your name: "
@@ -42,7 +42,7 @@ end</code></pre>
   </div>
 </div>
 
-<!-- .source-with-title -->
+<!-- .source_with_title -->
 <div class="listingblock">
   <div class="title">Odelay!</div>
   <div class="content">
@@ -52,7 +52,7 @@ end</code></pre>
   </div>
 </div>
 
-<!-- .source-with-language -->
+<!-- .source_with_language -->
 <div class="listingblock">
   <div class="content">
     <pre class="highlight">
@@ -63,7 +63,7 @@ end</code>
   </div>
 </div>
 
-<!-- .source-nowrap -->
+<!-- .source_nowrap -->
 <div class="listingblock">
   <div class="content">
     <pre class="highlight nowrap">
@@ -81,7 +81,7 @@ end</code>
   </div>
 </div>
 
-<!-- .source-highlighter-coderay -->
+<!-- .source_highlighter_coderay -->
 <div class="listingblock">
   <div class="content">
     <pre class="CodeRay highlight">
@@ -92,7 +92,7 @@ end</code>
   </div>
 </div>
 
-<!-- .source-highlighter-pygments -->
+<!-- .source_highlighter_pygments -->
 <div class="listingblock">
   <div class="content">
     <pre class="pygments highlight">
@@ -103,7 +103,7 @@ end</code>
   </div>
 </div>
 
-<!-- .source-highlighter-prettify -->
+<!-- .source_highlighter_prettify -->
 <div class="listingblock">
   <div class="content">
     <pre class="prettyprint highlight">
@@ -114,7 +114,7 @@ end</code>
   </div>
 </div>
 
-<!-- .source-highlighter-html-pipeline -->
+<!-- .source_highlighter_html_pipeline -->
 <div class="listingblock">
   <div class="content">
     <pre lang="ruby"><code>5.times do

--- a/test/examples/html5/block_literal.html
+++ b/test/examples/html5/block_literal.html
@@ -7,7 +7,7 @@ would you like to die again? y/n</pre>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="literalblock">
   <div class="title">Die again?</div>
   <div class="content">
@@ -17,7 +17,7 @@ would you like to die again? y/n</pre>
   </div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="literalblock fatal" id="error">
   <div class="content">
     <pre>error: The requested operation returned error: 1954 Forbidden search for defensive operations manual

--- a/test/examples/html5/block_olist.html
+++ b/test/examples/html5/block_olist.html
@@ -83,7 +83,6 @@
 
 <!-- .with-id-and-role -->
 <div class="olist arabic green" id="steps">
-  <div class="title">Steps</div>
   <ol class="arabic">
     <li>
       <p>Step 1</p>

--- a/test/examples/html5/block_olist.html
+++ b/test/examples/html5/block_olist.html
@@ -13,7 +13,7 @@
   </ol>
 </div>
 
-<!-- .with-start -->
+<!-- .with_start -->
 <div class="olist arabic">
   <ol class="arabic" start="6">
     <li>
@@ -28,7 +28,7 @@
   </ol>
 </div>
 
-<!-- .with-numeration-styles -->
+<!-- .with_numeration_styles -->
 <div class="olist decimal">
   <ol class="decimal">
     <li>
@@ -65,7 +65,7 @@
   </ol>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="olist arabic">
   <div class="title">Steps</div>
   <ol class="arabic">
@@ -81,7 +81,7 @@
   </ol>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="olist arabic green" id="steps">
   <ol class="arabic">
     <li>
@@ -96,7 +96,7 @@
   </ol>
 </div>
 
-<!-- .max-nesting -->
+<!-- .max_nesting -->
 <div class="olist arabic">
   <ol class="arabic">
     <li>
@@ -136,7 +136,7 @@
   </ol>
 </div>
 
-<!-- .complex-content -->
+<!-- .complex_content -->
 <div class="olist arabic">
   <ol class="arabic">
     <li>

--- a/test/examples/html5/block_open.html
+++ b/test/examples/html5/block_open.html
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<!-- .basic-with-title -->
+<!-- .basic_with_title -->
 <div class="openblock">
   <div class="title">An open block</div>
   <div class="content">
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<!-- .basic-with-id-and-role -->
+<!-- .basic_with_id_and_role -->
 <div class="openblock example" id="open">
   <div class="content">
     <div class="paragraph">
@@ -35,7 +35,7 @@
   </blockquote>
 </div>
 
-<!-- .abstract-with-title -->
+<!-- .abstract_with_title -->
 <div class="quoteblock abstract">
   <div class="title">Abstract title is abstract</div>
   <blockquote>
@@ -45,7 +45,7 @@
   </blockquote>
 </div>
 
-<!-- .abstract-with-id-and-role -->
+<!-- .abstract_with_id_and_role -->
 <div class="quoteblock abstract example" id="open">
   <blockquote>
     <div class="paragraph">

--- a/test/examples/html5/block_outline.html
+++ b/test/examples/html5/block_outline.html
@@ -1,0 +1,58 @@
+<!-- .basic
+:header_footer:
+:include: .//div[@id="toc"]/ul
+-->
+<ul class="sectlevel1">
+  <li><a href="#_section_1">Section 1</a></li>
+  <li>
+    <a href="#_section_2">Section 2</a>
+    <ul class="sectlevel2">
+      <li><a href="#_section_2_1">Section 2.1</a></li>
+    </ul>
+  </li>
+  <li><a href="#_section_3">Section 3</a></li>
+</ul>
+
+<!-- .toclevels
+:header_footer:
+:include: .//div[@id="toc"]/ul
+-->
+<ul class="sectlevel1">
+  <li><a href="#_section_1">Section 1</a></li>
+  <li><a href="#_section_2">Section 2</a></li>
+</ul>
+
+<!-- .numbered
+:header_footer:
+:include: .//div[@id="toc"]/ul
+-->
+<ul class="sectlevel1">
+  <li><a href="#_section_1">1. Section 1</a></li>
+  <li><a href="#_unnumbered_section">Unnumbered Section</a></li>
+  <li>
+    <a href="#_section_2">2. Section 2</a>
+    <ul class="sectlevel2">
+      <li><a href="#_section_2_1">2.1. Section 2.1</a></li>
+    </ul>
+  </li>
+  <li><a href="#_section_3">3. Section 3</a></li>
+</ul>
+
+<!-- .sectnumlevels
+:header_footer:
+:include: .//div[@id="toc"]/ul
+-->
+<ul class="sectlevel1">
+  <li>
+    <a href="#_section_1">1. Section 1</a>
+    <ul class="sectlevel2">
+      <li>
+        <a href="#_section_1_1">Section 1.1</a>
+        <ul class="sectlevel3">
+          <li><a href="#_section_1_1_1">Section 1.1.1</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li><a href="#_section_2">2. Section 2</a></li>
+</ul>

--- a/test/examples/html5/block_paragraph.html
+++ b/test/examples/html5/block_paragraph.html
@@ -7,7 +7,7 @@ A paragraph is just one or more lines of consecutive text.</p>
   <p>To begin a new paragraph, separate it by at least one blank line.</p>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="paragraph">
   <div class="title">Paragraphs</div>
   <p>Paragraphs don&#8217;t require any special markup in AsciiDoc.
@@ -17,7 +17,7 @@ A paragraph is just one or more lines of consecutive text.</p>
   <p>To begin a new paragraph, separate it by at least one blank line.</p>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="paragraph red" id="para-1">
   <p>Paragraphs don&#8217;t require any special markup in AsciiDoc.
 A paragraph is just one or more lines of consecutive text.</p>

--- a/test/examples/html5/block_pass.html
+++ b/test/examples/html5/block_pass.html
@@ -1,0 +1,2 @@
+<!-- .basic -->
+<p>Allons-y!</p>image:tiger.png[]

--- a/test/examples/html5/block_preamble.html
+++ b/test/examples/html5/block_preamble.html
@@ -11,7 +11,7 @@ Our intrepid team is in desperate need of double shot mochas, but the milk expir
   </div>
 </div>
 
-<!-- .toc-placement-preamble
+<!-- .toc_placement_preamble
 :header_footer:
 :include: .//div[@id="preamble"]
 -->

--- a/test/examples/html5/block_quote.html
+++ b/test/examples/html5/block_quote.html
@@ -4,13 +4,13 @@
 on this continent a new nation&#8230;&#8203;</blockquote>
 </div>
 
-<!-- .with-attribution -->
+<!-- .with_attribution -->
 <div class="quoteblock">
   <blockquote>A person who never made a mistake never tried anything new.</blockquote>
   <div class="attribution">&#8212; Albert Einstein</div>
 </div>
 
-<!-- .with-attribution-and-citetitle -->
+<!-- .with_attribution_and_citetitle -->
 <div class="quoteblock">
   <blockquote>Everybody remember where we parked.</blockquote>
   <div class="attribution">
@@ -19,13 +19,13 @@ on this continent a new nation&#8230;&#8203;</blockquote>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="quoteblock">
   <div class="title">After landing the cloaked Klingon bird of prey in Golden Gate park:</div>
   <blockquote>Everybody remember where we parked.</blockquote>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="quoteblock startrek" id="parking">
   <blockquote>Everybody remember where we parked.</blockquote>
 </div>

--- a/test/examples/html5/block_sidebar.html
+++ b/test/examples/html5/block_sidebar.html
@@ -9,7 +9,7 @@ for producing professional documents like DocBook and LaTeX.</p>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="sidebarblock">
   <div class="content">
     <div class="title">AsciiDoc history</div>
@@ -21,7 +21,7 @@ for producing professional documents like DocBook and LaTeX.</p>
   </div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="sidebarblock center" id="origin">
   <div class="content">
     <div class="paragraph">

--- a/test/examples/html5/block_stem.html
+++ b/test/examples/html5/block_stem.html
@@ -8,13 +8,13 @@
   <div class="content">\[C = \alpha + \beta Y^{\gamma} + \epsilon\]</div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="stemblock">
   <div class="title">Equation</div>
   <div class="content">\$sqrt(4) = 2\$</div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="stemblock right" id="sqrt">
   <div class="content">\$sqrt(4) = 2\$</div>
 </div>

--- a/test/examples/html5/block_table.html
+++ b/test/examples/html5/block_table.html
@@ -1,5 +1,5 @@
 <!-- .basic -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -33,7 +33,7 @@
 </table>
 
 <!-- .with-frame -->
-<table class="tableblock frame-sides grid-all" style="width: 100%;">
+<table class="tableblock frame-sides grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -51,7 +51,7 @@
 </table>
 
 <!-- .with-grid -->
-<table class="tableblock frame-all grid-cols" style="width: 100%;">
+<table class="tableblock frame-all grid-cols spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -69,7 +69,7 @@
 </table>
 
 <!-- .with-float -->
-<table class="tableblock frame-all grid-all" style="width: 100%; float: left;">
+<table class="tableblock frame-all grid-all spread" style="float: left;">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -123,7 +123,7 @@
 </table>
 
 <!-- .with-title -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <caption class="title">Table 1. Table FTW!</caption>
   <colgroup>
     <col style="width: 50%;">
@@ -142,7 +142,7 @@
 </table>
 
 <!-- .with-id-and-role -->
-<table class="tableblock frame-all grid-all center" id="tabular" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread center" id="tabular">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -160,7 +160,7 @@
 </table>
 
 <!-- .header -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -192,7 +192,7 @@
 </table>
 
 <!-- .footer -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">
@@ -228,7 +228,7 @@
 </table>
 
 <!-- .cols-width -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 20%;">
@@ -261,7 +261,7 @@
 </table>
 
 <!-- .cols-halign -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
     <col style="width: 33%;">
@@ -294,7 +294,7 @@
 </table>
 
 <!-- .cols-valign -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
     <col style="width: 33%;">
@@ -327,7 +327,7 @@
 </table>
 
 <!-- .cols-all-styles -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 14%;">
     <col style="width: 14%;">
@@ -369,7 +369,7 @@
 </table>
 
 <!-- .colspan -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
     <col style="width: 33%;">
@@ -399,7 +399,7 @@
 </table>
 
 <!-- .rowspan -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
     <col style="width: 33%;">
@@ -440,7 +440,7 @@
 </table>
 
 <!-- .aligns-per-cell -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
     <col style="width: 33%;">
@@ -478,7 +478,7 @@
 </table>
 
 <!-- .insane-cells-formatting -->
-<table class="tableblock frame-all grid-all" style="width: 100%;">
+<table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
     <col style="width: 50%;">

--- a/test/examples/html5/block_table.html
+++ b/test/examples/html5/block_table.html
@@ -24,7 +24,7 @@
   </tbody>
 </table>
 
-<!-- .with-frame-sides -->
+<!-- .with_frame_sides -->
 <table class="tableblock frame-sides grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -42,7 +42,7 @@
   </tbody>
 </table>
 
-<!-- .with-grid-cols -->
+<!-- .with_grid_cols -->
 <table class="tableblock frame-all grid-cols spread">
   <colgroup>
     <col style="width: 50%;">
@@ -60,7 +60,7 @@
   </tbody>
 </table>
 
-<!-- .with-float -->
+<!-- .with_float -->
 <table class="tableblock frame-all grid-all spread" style="float: left;">
   <colgroup>
     <col style="width: 50%;">
@@ -78,7 +78,7 @@
   </tbody>
 </table>
 
-<!-- .with-width -->
+<!-- .with_width -->
 <table class="tableblock frame-all grid-all" style="width: 80%;">
   <colgroup>
     <col style="width: 50%;">
@@ -96,7 +96,7 @@
   </tbody>
 </table>
 
-<!-- .with-autowidth -->
+<!-- .with_autowidth -->
 <table class="tableblock frame-all grid-all">
   <colgroup>
     <col>
@@ -114,7 +114,7 @@
   </tbody>
 </table>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <table class="tableblock frame-all grid-all spread">
   <caption class="title">Table 1. Table FTW!</caption>
   <colgroup>
@@ -133,7 +133,7 @@
   </tbody>
 </table>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <table class="tableblock frame-all grid-all spread center" id="tabular">
   <colgroup>
     <col style="width: 50%;">
@@ -151,7 +151,7 @@
   </tbody>
 </table>
 
-<!-- .with-header -->
+<!-- .with_header -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -183,7 +183,7 @@
   </tbody>
 </table>
 
-<!-- .with-footer -->
+<!-- .with_footer -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -219,7 +219,7 @@
   </tbody>
 </table>
 
-<!-- .with-cols-width -->
+<!-- .with_cols_width -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -241,7 +241,7 @@
   </tbody>
 </table>
 
-<!-- .with-cols-halign -->
+<!-- .with_cols_halign -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
@@ -263,7 +263,7 @@
   </tbody>
 </table>
 
-<!-- .with-cols-valign -->
+<!-- .with_cols_valign -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
@@ -285,7 +285,7 @@
   </tbody>
 </table>
 
-<!-- .with-cols-styles -->
+<!-- .with_cols_styles -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 14%;">
@@ -329,7 +329,7 @@
   </tbody>
 </table>
 
-<!-- .cell-with-paragraphs -->
+<!-- .cell_with_paragraphs -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 100%;">
@@ -420,7 +420,7 @@
   </tbody>
 </table>
 
-<!-- .aligns-per-cell -->
+<!-- .aligns_per_cell -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
@@ -458,7 +458,7 @@
   </tbody>
 </table>
 
-<!-- .insane-cells-formatting -->
+<!-- .insane_cells_formatting -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">

--- a/test/examples/html5/block_table.html
+++ b/test/examples/html5/block_table.html
@@ -21,18 +21,10 @@
         <p class="tableblock">Cell in column 2, row 2</p>
       </td>
     </tr>
-    <tr>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 1, row 3</p>
-      </td>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 2, row 3</p>
-      </td>
-    </tr>
   </tbody>
 </table>
 
-<!-- .with-frame -->
+<!-- .with-frame-sides -->
 <table class="tableblock frame-sides grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -50,7 +42,7 @@
   </tbody>
 </table>
 
-<!-- .with-grid -->
+<!-- .with-grid-cols -->
 <table class="tableblock frame-all grid-cols spread">
   <colgroup>
     <col style="width: 50%;">
@@ -159,7 +151,7 @@
   </tbody>
 </table>
 
-<!-- .header -->
+<!-- .with-header -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -191,7 +183,7 @@
   </tbody>
 </table>
 
-<!-- .footer -->
+<!-- .with-footer -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -227,7 +219,7 @@
   </tbody>
 </table>
 
-<!-- .cols-width -->
+<!-- .with-cols-width -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 50%;">
@@ -246,21 +238,10 @@
         <p class="tableblock">Cell in column 3, row 1</p>
       </td>
     </tr>
-    <tr>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 1, row 2</p>
-      </td>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 2, row 2</p>
-      </td>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 3, row 2</p>
-      </td>
-    </tr>
   </tbody>
 </table>
 
-<!-- .cols-halign -->
+<!-- .with-cols-halign -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
@@ -279,21 +260,10 @@
         <p class="tableblock">Cell in column 3, row 1</p>
       </td>
     </tr>
-    <tr>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 1, row 2</p>
-      </td>
-      <td class="tableblock halign-center valign-top">
-        <p class="tableblock">Cell in column 2, row 2</p>
-      </td>
-      <td class="tableblock halign-right valign-top">
-        <p class="tableblock">Cell in column 3, row 2</p>
-      </td>
-    </tr>
   </tbody>
 </table>
 
-<!-- .cols-valign -->
+<!-- .with-cols-valign -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 33%;">
@@ -312,21 +282,10 @@
         <p class="tableblock">Cell in column 3, row 1</p>
       </td>
     </tr>
-    <tr>
-      <td class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 1, row 2</p>
-      </td>
-      <td class="tableblock halign-left valign-middle">
-        <p class="tableblock">Cell in column 2, row 2</p>
-      </td>
-      <td class="tableblock halign-left valign-bottom">
-        <p class="tableblock">Cell in column 3, row 2</p>
-      </td>
-    </tr>
   </tbody>
 </table>
 
-<!-- .cols-all-styles -->
+<!-- .with-cols-styles -->
 <table class="tableblock frame-all grid-all spread">
   <colgroup>
     <col style="width: 14%;">
@@ -341,28 +300,50 @@
     <tr>
       <td class="tableblock halign-left valign-top">
         <div>
-          <div class="paragraph">
-            <p>Cell in column 1, row 1</p>
+          <div class="imageblock">
+            <div class="content">
+              <img alt="AsciiDoc content" src="sunset.jpg">
+            </div>
           </div>
         </div>
       </td>
       <td class="tableblock halign-left valign-top">
-        <p class="tableblock"><em>Cell in column 2, row 1</em></p>
+        <p class="tableblock"><em>Emphasized text</em></p>
       </td>
       <th class="tableblock halign-left valign-top">
-        <p class="tableblock">Cell in column 3, row 1</p>
+        <p class="tableblock">Styled like a header</p>
       </th>
       <td class="tableblock halign-left valign-top">
-        <div class="literal"><pre>Cell in column 4, row 1</pre></div>
+        <div class="literal"><pre>Literal block</pre></div>
       </td>
       <td class="tableblock halign-left valign-top">
-        <p class="tableblock"><code>Cell in column 5, row 1</code></p>
+        <p class="tableblock"><code>Monospaced text</code></p>
       </td>
       <td class="tableblock halign-left valign-top">
-        <p class="tableblock"><strong>Cell in column 6, row 1</strong></p>
+        <p class="tableblock"><strong>Strong text</strong></p>
       </td>
       <td class="tableblock halign-left valign-top">
-        <div class="verse">Cell in column 7, row 1</div>
+        <div class="verse">Verse block</div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- .cell-with-paragraphs -->
+<table class="tableblock frame-all grid-all spread">
+  <colgroup>
+    <col style="width: 100%;">
+  </colgroup>
+  <tbody>
+    <tr>
+      <td class="tableblock halign-left valign-top">
+        <p class="tableblock">Single paragraph on row 1</p>
+      </td>
+    </tr>
+    <tr>
+      <td class="tableblock halign-left valign-top">
+        <p class="tableblock">First paragraph on row 2</p>
+        <p class="tableblock">Second paragraph on row 2</p>
       </td>
     </tr>
   </tbody>

--- a/test/examples/html5/block_toc.html
+++ b/test/examples/html5/block_toc.html
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<!-- .with-title
+<!-- .with_title
 :include: .//div[@id="toc"]
 -->
 <div class="toc" id="toc">
@@ -34,7 +34,7 @@
   </ul>
 </div>
 
-<!-- .with-levels
+<!-- .with_levels
 :include: .//div[@id="toc"]
 -->
 <div class="toc" id="toc">
@@ -45,7 +45,7 @@
   </ul>
 </div>
 
-<!-- .with-id-and-role
+<!-- .with_id_and_role
 :include: .//div[@id="mytoc"]
 -->
 <div class="taco" id="mytoc">

--- a/test/examples/html5/block_toc.html
+++ b/test/examples/html5/block_toc.html
@@ -1,50 +1,57 @@
 <!-- .basic
-:header_footer:
-:include: .//*[@id="toc"]
+:include: ./div[1]
 -->
-<div class="toc" id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <ul class="sectlevel1">
-    <li><a href="#_cavern_glow">Cavern Glow</a></li>
-    <li>
-      <a href="#_the_ravages_of_writing">The Ravages of Writing</a>
-      <ul class="sectlevel2">
-        <li><a href="#_a_recipe_for_potion">A Recipe for Potion</a></li>
+<div class="sect1">
+  <h2 id="_introduction">Introduction</h2>
+  <div class="sectionbody">
+    <div class="toc" id="toc">
+      <div class="title" id="toctitle">Table of Contents</div>
+      <ul class="sectlevel1">
+        <li>
+          <a href="#_introduction">Introduction</a>
+        </li>
+        <li>
+          <a href="#_the_ravages_of_writing">The Ravages of Writing</a>
+          <ul class="sectlevel2">
+            <li>
+              <a href="#_a_recipe_for_potion">A Recipe for Potion</a>
+            </li>
+          </ul>
+        </li>
       </ul>
-    </li>
-  </ul>
+    </div>
+  </div>
 </div>
 
-<!-- .toc-title
-:header_footer:
-:include: .//*[@id="toc"]
+<!-- .with-title
+:include: .//div[@id="toc"]
 -->
 <div class="toc" id="toc">
-  <div id="toctitle">Table of Adventures</div>
-  <ul class="sectlevel1">
-    <li><a href="#_cavern_glow">Cavern Glow</a></li>
-  </ul>
-</div>
-
-<!-- .toclevels-1
-:header_footer:
-:include: .//*[@id="toc"]
--->
-<div class="toc" id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <ul class="sectlevel1">
-    <li><a href="#_cavern_glow">Cavern Glow</a></li>
-  </ul>
-</div>
-
-<!-- .custom-placement-role-and-id
-:header_footer:
-:include: .//*[@id="my-toc"]
--->
-<div class="awesome-toc" id="my-toc">
-  <div class="title" id="my-toctitle">Table of Contents</div>
+  <div class="title" id="toctitle">Table of Adventures</div>
   <ul class="sectlevel1">
     <li><a href="#_introduction">Introduction</a></li>
-    <li><a href="#_cavern_glow">Cavern Glow</a></li>
+    <li><a href="#_the_ravages_of_writing">The Ravages of Writing</a></li>
+  </ul>
+</div>
+
+<!-- .with-levels
+:include: .//div[@id="toc"]
+-->
+<div class="toc" id="toc">
+  <div class="title" id="toctitle">Table of Contents</div>
+  <ul class="sectlevel1">
+    <li><a href="#_introduction">Introduction</a></li>
+    <li><a href="#_the_ravages_of_writing">The Ravages of Writing</a></li>
+  </ul>
+</div>
+
+<!-- .with-id-and-role
+:include: .//div[@id="mytoc"]
+-->
+<div class="taco" id="mytoc">
+  <div class="title" id="mytoctitle">Table of Contents</div>
+  <ul class="sectlevel1">
+    <li><a href="#_introduction">Introduction</a></li>
+    <li><a href="#_the_ravages_of_writing">The Ravages of Writing</a></li>
   </ul>
 </div>

--- a/test/examples/html5/block_ulist.html
+++ b/test/examples/html5/block_ulist.html
@@ -13,7 +13,7 @@
   </ul>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="ulist">
   <div class="title">Writers</div>
   <ul>
@@ -29,7 +29,7 @@
   </ul>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="ulist green" id="authors">
   <ul>
     <li>
@@ -44,7 +44,7 @@
   </ul>
 </div>
 
-<!-- .max-nesting -->
+<!-- .max_nesting -->
 <div class="ulist">
   <ul>
     <li>
@@ -84,7 +84,7 @@
   </ul>
 </div>
 
-<!-- .complex-content -->
+<!-- .complex_content -->
 <div class="ulist">
   <ul>
     <li>
@@ -132,7 +132,7 @@ a list continuation on a line adjacent to both blocks.</p>
   </ul>
 </div>
 
-<!-- .checklist-icons-font -->
+<!-- .checklist_icons_font -->
 <div class="ulist checklist">
   <ul class="checklist">
     <li>
@@ -150,7 +150,7 @@ a list continuation on a line adjacent to both blocks.</p>
   </ul>
 </div>
 
-<!-- .checklist-interactive -->
+<!-- .checklist_interactive -->
 <div class="ulist checklist">
   <ul class="checklist">
     <li>

--- a/test/examples/html5/block_verse.html
+++ b/test/examples/html5/block_verse.html
@@ -4,14 +4,14 @@
 on little cat feet.</pre>
 </div>
 
-<!-- .basic-with-attribution -->
+<!-- .basic_with_attribution -->
 <div class="verseblock">
   <pre class="content">The fog comes
 on little cat feet.</pre>
   <div class="attribution">&#8212; Carl Sandburg</div>
 </div>
 
-<!-- .basic-with-attribution-and-citetitle -->
+<!-- .basic_with_attribution_and_citetitle -->
 <div class="verseblock">
   <pre class="content">The fog comes
 on little cat feet.</pre>
@@ -21,14 +21,14 @@ on little cat feet.</pre>
   </div>
 </div>
 
-<!-- .basic-with-title -->
+<!-- .basic_with_title -->
 <div class="verseblock">
   <div class="title">Poetry</div>
   <pre class="content">The fog comes
 on little cat feet.</pre>
 </div>
 
-<!-- .basic-with-id-and-role -->
+<!-- .basic_with_id_and_role -->
 <div class="verseblock center" id="sandburg">
   <pre class="content">The fog comes
 on little cat feet.</pre>

--- a/test/examples/html5/block_video.html
+++ b/test/examples/html5/block_video.html
@@ -5,17 +5,53 @@
   </div>
 </div>
 
-<!-- .basic-with-all-attributes -->
+<!-- .with-poster -->
 <div class="videoblock">
   <div class="content">
-    <video controls height="480" poster="sunset.jpg" src="video_file.mp4#t=10,60" width="640">Your browser does not support the video tag.</video>
+    <video controls poster="sunset.jpg" src="video_file.mp4">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .basic-with-all-options -->
+<!-- .with-dimensions -->
+<div class="videoblock">
+  <div class="content">
+    <video controls height="480" src="video_file.mp4" width="640">Your browser does not support the video tag.</video>
+  </div>
+</div>
+
+<!-- .with-start -->
+<div class="videoblock">
+  <div class="content">
+    <video controls src="video_file.mp4#t=10">Your browser does not support the video tag.</video>
+  </div>
+</div>
+
+<!-- .with-end -->
+<div class="videoblock">
+  <div class="content">
+    <video controls src="video_file.mp4#t=,60">Your browser does not support the video tag.</video>
+  </div>
+</div>
+
+<!-- .with-options -->
 <div class="videoblock">
   <div class="content">
     <video autoplay loop src="video_file.mp4">Your browser does not support the video tag.</video>
+  </div>
+</div>
+
+<!-- .with-title -->
+<div class="videoblock">
+  <div class="title">Must watch!</div>
+  <div class="content">
+    <video controls src="video_file.mp4">Your browser does not support the video tag.</video>
+  </div>
+</div>
+
+<!-- .with-id-and-role -->
+<div class="videoblock watch" id="lindsey">
+  <div class="content">
+    <video controls src="video_file.mp4">Your browser does not support the video tag.</video>
   </div>
 </div>
 
@@ -58,20 +94,5 @@
 <div class="videoblock">
   <div class="content">
     <iframe allowFullScreen frameborder="0" src="//player.vimeo.com/video/32255377#at=60?autoplay=1&amp;loop=1"></iframe>
-  </div>
-</div>
-
-<!-- .with-title -->
-<div class="videoblock">
-  <div class="title">Must watch!</div>
-  <div class="content">
-    <video controls src="video_file.mp4">Your browser does not support the video tag.</video>
-  </div>
-</div>
-
-<!-- .with-id-and-role -->
-<div class="videoblock watch" id="lindsey">
-  <div class="content">
-    <video controls src="video_file.mp4">Your browser does not support the video tag.</video>
   </div>
 </div>

--- a/test/examples/html5/block_video.html
+++ b/test/examples/html5/block_video.html
@@ -5,42 +5,42 @@
   </div>
 </div>
 
-<!-- .with-poster -->
+<!-- .with_poster -->
 <div class="videoblock">
   <div class="content">
     <video controls poster="sunset.jpg" src="video_file.mp4">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .with-dimensions -->
+<!-- .with_dimensions -->
 <div class="videoblock">
   <div class="content">
     <video controls height="480" src="video_file.mp4" width="640">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .with-start -->
+<!-- .with_start -->
 <div class="videoblock">
   <div class="content">
     <video controls src="video_file.mp4#t=10">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .with-end -->
+<!-- .with_end -->
 <div class="videoblock">
   <div class="content">
     <video controls src="video_file.mp4#t=,60">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .with-options -->
+<!-- .with_options -->
 <div class="videoblock">
   <div class="content">
     <video autoplay loop src="video_file.mp4">Your browser does not support the video tag.</video>
   </div>
 </div>
 
-<!-- .with-title -->
+<!-- .with_title -->
 <div class="videoblock">
   <div class="title">Must watch!</div>
   <div class="content">
@@ -48,7 +48,7 @@
   </div>
 </div>
 
-<!-- .with-id-and-role -->
+<!-- .with_id_and_role -->
 <div class="videoblock watch" id="lindsey">
   <div class="content">
     <video controls src="video_file.mp4">Your browser does not support the video tag.</video>
@@ -62,14 +62,14 @@
   </div>
 </div>
 
-<!-- .youtube-iframe-params -->
+<!-- .youtube_iframe_params -->
 <div class="videoblock">
   <div class="content">
     <iframe frameborder="0" height="480" src="//www.youtube.com/embed/rPQoq7ThGAU?rel=0" width="640"></iframe>
   </div>
 </div>
 
-<!-- .youtube-url-params -->
+<!-- .youtube_url_params -->
 <div class="videoblock">
   <div class="content">
     <iframe allowfullscreen frameborder="0" src="//www.youtube.com/embed/rPQoq7ThGAU?rel=0&amp;start=60&amp;end=140&amp;autoplay=1&amp;loop=1"></iframe>
@@ -83,14 +83,14 @@
   </div>
 </div>
 
-<!-- .vimeo-iframe-params -->
+<!-- .vimeo_iframe_params -->
 <div class="videoblock">
   <div class="content">
     <iframe frameborder="0" height="480" src="//player.vimeo.com/video/32255377" width="640"></iframe>
   </div>
 </div>
 
-<!-- .vimeo-url-params -->
+<!-- .vimeo_url_params -->
 <div class="videoblock">
   <div class="content">
     <iframe allowFullScreen frameborder="0" src="//player.vimeo.com/video/32255377#at=60?autoplay=1&amp;loop=1"></iframe>

--- a/test/examples/html5/block_video.html
+++ b/test/examples/html5/block_video.html
@@ -8,7 +8,7 @@
 <!-- .basic-with-all-attributes -->
 <div class="videoblock">
   <div class="content">
-    <video controls height="480" poster="sunset.jpg" src="video_file.mp4" width="640">Your browser does not support the video tag.</video>
+    <video controls height="480" poster="sunset.jpg" src="video_file.mp4#t=10,60" width="640">Your browser does not support the video tag.</video>
   </div>
 </div>
 

--- a/test/examples/html5/document.html
+++ b/test/examples/html5/document.html
@@ -5,7 +5,7 @@
   <h1>The Dangerous and Thrilling Documentation Chronicles</h1>
 </div>
 
-<!-- .title-with-author
+<!-- .title_with_author
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<!-- .title-with-author-no-email
+<!-- .title_with_author_no_email
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -29,7 +29,7 @@
   </div>
 </div>
 
-<!-- .title-with-multiple-authors
+<!-- .title_with_multiple_authors
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -45,7 +45,7 @@
   </div>
 </div>
 
-<!-- .title-with-revnumber
+<!-- .title_with_revnumber
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -57,7 +57,7 @@
   </div>
 </div>
 
-<!-- .title-with-revdate
+<!-- .title_with_revdate
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -69,7 +69,7 @@
   </div>
 </div>
 
-<!-- .title-with-revremark
+<!-- .title_with_revremark
 :include: .//body/div[@id="header"]
 -->
 <div id="header">
@@ -109,7 +109,7 @@
   </div>
 </div>
 
-<!-- .toc-title
+<!-- .toc_title
 :include: .//div[@id="header"]
 -->
 <div id="header">

--- a/test/examples/html5/document.html
+++ b/test/examples/html5/document.html
@@ -95,3 +95,30 @@
     <a href="#_footnoteref_2">2</a>. Opinions are my own.
   </div>
 </div>
+
+<!-- .toc
+:include: .//div[@id="header"]
+-->
+<div id="header">
+  <h1>Document Title</h1>
+  <div class="toc" id="toc">
+    <div id="toctitle">Table of Contents</div>
+    <ul class="sectlevel1">
+      <li><a href="#_cavern_glow">Cavern Glow</a></li>
+    </ul>
+  </div>
+</div>
+
+<!-- .toc-title
+:include: .//div[@id="header"]
+-->
+<div id="header">
+  <h1>Document Title</h1>
+    <div class="toc" id="toc">
+      <div id="toctitle">Table of Adventures</div>
+      <ul class="sectlevel1">
+        <li><a href="#_cavern_glow">Cavern Glow</a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/test/examples/html5/inline_anchor.html
+++ b/test/examples/html5/inline_anchor.html
@@ -1,22 +1,22 @@
 <!-- .basic -->
 <a class="bare" href="http://www.asciidoctor.org">http://www.asciidoctor.org</a>
 
-<!-- .basic-with-text -->
+<!-- .basic_with_text -->
 <a href="irc://irc.freenode.org/#asciidoctor">Asciidoctor IRC channel</a>
 
-<!-- .basic-with-target-blank -->
+<!-- .basic_with_target_blank -->
 <a href="view-source:asciidoctor.org" target="_blank">Asciidoctor homepage</a>
 
-<!-- .basic-with-role -->
+<!-- .basic_with_role -->
 <a class="green" href="http://discuss.asciidoctor.org/"><strong>mailing list</strong></a>
 
 <!-- .xref -->
 The section <a href="#page-break">[page-break]</a> describes how to add a page break.
 
-<!-- .xref-with-text -->
+<!-- .xref_with_text -->
 The section <a href="#page-break">Page break</a> describes how to add a page break.
 
-<!-- .xref-resolved-text -->
+<!-- .xref_resolved_text -->
 Refer to <a href="#_section_a">Section A</a>.
 
 <!-- .bibref -->

--- a/test/examples/html5/inline_anchor.html
+++ b/test/examples/html5/inline_anchor.html
@@ -20,5 +20,4 @@ The section <a href="#page-break">Page break</a> describes how to add a page bre
 Refer to <a href="#_section_a">Section A</a>.
 
 <!-- .bibref -->
-<a id="prag"></a>[prag] Andy Hunt &amp; Dave Thomas. The Pragmatic Programmer:
-From Journeyman to Master. Addison-Wesley. 1999.
+<a id="prag"></a>[prag] Andy Hunt &amp; Dave Thomas. The Pragmatic Programmer

--- a/test/examples/html5/inline_break.html
+++ b/test/examples/html5/inline_break.html
@@ -1,4 +1,4 @@
-<!-- .plus-sign -->
+<!-- .plus_sign -->
 Rubies are red,<br>
 Topazes are blue.
 

--- a/test/examples/html5/inline_callout.html
+++ b/test/examples/html5/inline_callout.html
@@ -3,12 +3,12 @@
 -->
 "Hello world!" <b class="conum">(1)</b>
 
-<!-- .icons-image
+<!-- .icons_image
 :include: .//code/node()
 -->
 "Hello world!" <img alt="1" src="./images/icons/callouts/1.png">
 
-<!-- .icons-font
+<!-- .icons_font
 :include: .//code/node()
 -->
 "Hello world!" <i class="conum" data-value="1"></i><b>(1)</b>

--- a/test/examples/html5/inline_footnote.html
+++ b/test/examples/html5/inline_footnote.html
@@ -1,11 +1,9 @@
 <!-- .basic
-// footnotes list is tested in document and embedded
 :exclude: ./div[@id="footnotes"]
 -->
 Apocalyptic party.<span class="footnote">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span>
 
 <!-- .xref
-// footnotes list is tested in document and embedded
 :exclude: ./div[@id="footnotes"]
 -->
 A bold statement.<span class="footnote" id="_footnote_disclaimer">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span>

--- a/test/examples/html5/inline_footnote.html
+++ b/test/examples/html5/inline_footnote.html
@@ -9,5 +9,5 @@ Apocalyptic party.<span class="footnote">[<a class="footnote" href="#_footnote_1
 A bold statement.<span class="footnote" id="_footnote_disclaimer">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span>
 Another outrageous statement.<span class="footnoteref">[<a class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</span>
 
-<!-- .xref-unresolved -->
+<!-- .xref_unresolved -->
 A bold statement.<span class="footnoteref red" title="Unresolved footnote reference.">[foobar]</span>

--- a/test/examples/html5/inline_image.html
+++ b/test/examples/html5/inline_image.html
@@ -16,20 +16,29 @@
 <!-- .image-with-role -->
 <span class="image black"><img alt="linux" src="linux.svg"></span>
 
+<!-- .icon -->
+<span class="icon"><img alt="tags" src="./images/icons/tags.png"></span>
+
+<!-- .icon-with-dimensions -->
+<span class="icon"><img alt="tags" height="25" src="./images/icons/tags.png" width="35"></span>
+
+<!-- .icon-with-float -->
+<span class="icon" style="float: right;"><img alt="heart" src="./images/icons/heart.png"></span>
+
+<!-- .icon-with-link -->
+<span class="icon"><a class="image" href="http://rubygems.org/downloads/asciidoctor-1.5.2.gem"><img alt="download" src="./images/icons/download.png"></a></span>
+
+<!-- .icon-with-title -->
+<span class="icon"><img alt="heart" src="./images/icons/heart.png" title="I &lt;3 Asciidoctor"></span>
+
+<!-- .icon-with-role -->
+<span class="icon blue"><img alt="tags" src="./images/icons/tags.png"></span>
+
 <!-- .icon-no-icons -->
 <span class="icon">[tags]</span>
 
-<!-- .icon-image -->
-<span class="icon"><img alt="tags" src="./images/icons/tags.png"></span>
-
 <!-- .icon-font -->
 <span class="icon"><i class="fa fa-heart"></i></span>
-
-<!-- .icon-font-with-float -->
-<span class="icon" style="float: right;"><i class="fa fa-heart"></i></span>
-
-<!-- .icon-font-with-link -->
-<span class="icon"><a class="image" href="http://rubygems.org/downloads/asciidoctor-1.5.2.gem"><i class="fa fa-download"></i></a></span>
 
 <!-- .icon-font-with-title -->
 <span class="icon"><i class="fa fa-heart" title="I &lt;3 Asciidoctor"></i></span>

--- a/test/examples/html5/inline_image.html
+++ b/test/examples/html5/inline_image.html
@@ -1,53 +1,53 @@
 <!-- .image -->
 <span class="image"><img alt="linux" src="linux.svg"></span>
 
-<!-- .image-with-alt-text -->
+<!-- .image_with_alt_text -->
 <span class="image"><img alt="Tux" src="linux.svg"></span>
 
-<!-- .image-with-dimensions -->
+<!-- .image_with_dimensions -->
 <span class="image"><img alt="Tux" height="35" src="linux.svg" width="25"></span>
 
-<!-- .image-with-float -->
+<!-- .image_with_float -->
 <span class="image" style="float: right;"><img alt="linux" src="linux.svg"></span>
 
-<!-- .image-with-link -->
+<!-- .image_with_link -->
 <span class="image"><a class="image" href="http://inkscape.org/doc/examples/tux.svg"><img alt="linux" src="linux.svg"></a></span>
 
-<!-- .image-with-role -->
+<!-- .image_with_role -->
 <span class="image black"><img alt="linux" src="linux.svg"></span>
 
 <!-- .icon -->
 <span class="icon"><img alt="tags" src="./images/icons/tags.png"></span>
 
-<!-- .icon-with-dimensions -->
+<!-- .icon_with_dimensions -->
 <span class="icon"><img alt="tags" height="25" src="./images/icons/tags.png" width="35"></span>
 
-<!-- .icon-with-float -->
+<!-- .icon_with_float -->
 <span class="icon" style="float: right;"><img alt="heart" src="./images/icons/heart.png"></span>
 
-<!-- .icon-with-link -->
+<!-- .icon_with_link -->
 <span class="icon"><a class="image" href="http://rubygems.org/downloads/asciidoctor-1.5.2.gem"><img alt="download" src="./images/icons/download.png"></a></span>
 
-<!-- .icon-with-title -->
+<!-- .icon_with_title -->
 <span class="icon"><img alt="heart" src="./images/icons/heart.png" title="I &lt;3 Asciidoctor"></span>
 
-<!-- .icon-with-role -->
+<!-- .icon_with_role -->
 <span class="icon blue"><img alt="tags" src="./images/icons/tags.png"></span>
 
-<!-- .icon-no-icons -->
+<!-- .icon_no_icons -->
 <span class="icon">[tags]</span>
 
-<!-- .icon-font -->
+<!-- .icon_font -->
 <span class="icon"><i class="fa fa-heart"></i></span>
 
-<!-- .icon-font-with-title -->
+<!-- .icon_font_with_title -->
 <span class="icon"><i class="fa fa-heart" title="I &lt;3 Asciidoctor"></i></span>
 
-<!-- .icon-font-with-size -->
+<!-- .icon_font_with_size -->
 <span class="icon"><i class="fa fa-shield fa-2x"></i></span>
 
-<!-- .icon-font-with-rotate -->
+<!-- .icon_font_with_rotate -->
 <span class="icon"><i class="fa fa-shield fa-rotate-90"></i></span>
 
-<!-- .icon-font-with-flip -->
+<!-- .icon_font_with_flip -->
 <span class="icon"><i class="fa fa-shield fa-flip-vertical"></i></span>

--- a/test/examples/html5/inline_quoted.html
+++ b/test/examples/html5/inline_quoted.html
@@ -4,31 +4,31 @@
 <!-- .emphasis -->
 <em>chunky bacon</em>
 
-<!-- .emphasis-with-role -->
+<!-- .emphasis_with_role -->
 <em class="why">chunky bacon</em>
 
 <!-- .strong -->
 <strong>chunky bacon</strong>
 
-<!-- .strong-with-role -->
+<!-- .strong_with_role -->
 <strong class="why">chunky bacon</strong>
 
 <!-- .monospaced -->
 <code>hello world!</code>
 
-<!-- .monospaced-with-role -->
+<!-- .monospaced_with_role -->
 <code class="why">hello world!</code>
 
 <!-- .superscript -->
 <sup>super</sup>chunky bacon
 
-<!-- .superscript-with-role -->
+<!-- .superscript_with_role -->
 <sup class="why">super</sup>chunky bacon
 
 <!-- .subscript -->
 <sub>sub</sub>chunky bacon
 
-<!-- .subscript-with-role -->
+<!-- .subscript_with_role -->
 <sub class="why">sub</sub>chunky bacon
 
 <!-- .mark -->
@@ -37,13 +37,13 @@
 <!-- .double -->
 “chunky bacon”
 
-<!-- .double-with-role -->
+<!-- .double_with_role -->
 <span class="why">“chunky bacon”</span>
 
 <!-- .single -->
 ‘chunky bacon’
 
-<!-- .single-with-role -->
+<!-- .single_with_role -->
 <span class="why">‘chunky bacon’</span>
 
 <!-- .asciimath -->
@@ -52,8 +52,8 @@
 <!-- .latexmath -->
 \($C = \alpha + \beta Y^{\gamma} + \epsilon$\)
 
-<!-- .with-id -->
+<!-- .with_id -->
 <a id="why"></a><em>chunky bacon</em>
 
-<!-- .mixed-monospace-bold-italic -->
+<!-- .mixed_monospace_bold_italic -->
 <code><strong><em>monospace bold italic phrase</em></strong></code> and le<code><strong><em>tt</em></strong></code>ers

--- a/test/examples/html5/inline_quoted.html
+++ b/test/examples/html5/inline_quoted.html
@@ -1,22 +1,22 @@
 <!-- .basic -->
 <span class="why">chunky bacon</span>
 
-<!-- .italic -->
+<!-- .emphasis -->
 <em>chunky bacon</em>
 
-<!-- .italic-with-role -->
+<!-- .emphasis-with-role -->
 <em class="why">chunky bacon</em>
 
-<!-- .bold -->
+<!-- .strong -->
 <strong>chunky bacon</strong>
 
-<!-- .bold-with-role -->
+<!-- .strong-with-role -->
 <strong class="why">chunky bacon</strong>
 
-<!-- .monospace -->
+<!-- .monospaced -->
 <code>hello world!</code>
 
-<!-- .monospace-with-role -->
+<!-- .monospaced-with-role -->
 <code class="why">hello world!</code>
 
 <!-- .superscript -->
@@ -34,16 +34,16 @@
 <!-- .mark -->
 <mark>chunky bacon</mark>
 
-<!-- .double-curved-quotes -->
+<!-- .double -->
 “chunky bacon”
 
-<!-- .double-curved-quotes-with-role -->
+<!-- .double-with-role -->
 <span class="why">“chunky bacon”</span>
 
-<!-- .single-curved-quotes -->
+<!-- .single -->
 ‘chunky bacon’
 
-<!-- .single-curved-quotes-with-role -->
+<!-- .single-with-role -->
 <span class="why">‘chunky bacon’</span>
 
 <!-- .asciimath -->

--- a/test/examples/html5/section.html
+++ b/test/examples/html5/section.html
@@ -25,7 +25,7 @@
   <h6 id="_section_level_5">Section Level 5</h6>
 </div>
 
-<!-- .max-nesting -->
+<!-- .max_nesting -->
 <div class="sect1">
   <h2 id="_section_level_1">Section Level 1</h2>
   <div class="sectionbody">
@@ -47,14 +47,14 @@
   </div>
 </div>
 
-<!-- .with-custom-id -->
+<!-- .with_custom_id -->
 <div class="sect1">
   <h2 id="foo">Section Title</h2>
   <div class="sectionbody">
   </div>
 </div>
 
-<!-- .with-roles -->
+<!-- .with_roles -->
 <div class="sect1 center red">
   <h2 id="_section_title">Section Title</h2>
   <div class="sectionbody">
@@ -104,7 +104,7 @@
   </div>
 </div>
 
-<!-- .numbered-sectnumlevels-1 -->
+<!-- .numbered_sectnumlevels_1 -->
 <div class="sect1">
   <h2 id="_introduction_to_asciidoctor">1. Introduction to Asciidoctor</h2>
   <div class="sectionbody">

--- a/test/html5_haml_test.rb
+++ b/test/html5_haml_test.rb
@@ -3,7 +3,7 @@ require 'tilt/haml'
 
 class TestHamlHtml5 < DocTest::Test
 
-  renderer_opts template_dirs: 'haml/html5'
+  converter_opts template_dirs: 'haml/html5'
 
   generate_tests! DocTest::HTML::ExamplesSuite.new(paragraph_xpath: './div/p/node()')
 end

--- a/test/html5_haml_test.rb
+++ b/test/html5_haml_test.rb
@@ -1,13 +1,9 @@
 require 'test_helper'
 require 'tilt/haml'
 
-module Asciidoctor
-  module DocTest
-    class TestHamlHtml5 < HtmlTest
+class TestHamlHtml5 < DocTest::Test
 
-      templates_path 'haml/html5'
+  renderer_opts template_dirs: 'haml/html5'
 
-      generate_tests! AsciidocSuiteParser.new, HtmlSuiteParser.new(backend_name: :html5)
-    end
-  end
+  generate_tests! DocTest::HTML::ExamplesSuite.new(paragraph_xpath: './div/p/node()')
 end

--- a/test/html5_slim_test.rb
+++ b/test/html5_slim_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class TestSlimHtml5 < DocTest::Test
 
-  renderer_opts template_dirs: 'slim/html5'
+  converter_opts template_dirs: 'slim/html5'
 
   generate_tests! DocTest::HTML::ExamplesSuite.new(paragraph_xpath: './div/p/node()')
 end

--- a/test/html5_slim_test.rb
+++ b/test/html5_slim_test.rb
@@ -1,12 +1,8 @@
 require 'test_helper'
 
-module Asciidoctor
-  module DocTest
-    class TestSlimHtml5 < HtmlTest
+class TestSlimHtml5 < DocTest::Test
 
-      templates_path 'slim/html5'
+  renderer_opts template_dirs: 'slim/html5'
 
-      generate_tests! AsciidocSuiteParser.new, HtmlSuiteParser.new(backend_name: :html5)
-    end
-  end
+  generate_tests! DocTest::HTML::ExamplesSuite.new(paragraph_xpath: './div/p/node()')
 end

--- a/test/tasks/generate.rake
+++ b/test/tasks/generate.rake
@@ -20,7 +20,7 @@ namespace :generate do
       examples_path: 'test/examples/html5',
       paragraph_xpath: './div/p/node()'
     )
-    task.renderer_opts[:template_dirs] = File.join engine, 'html5'
+    task.converter_opts[:template_dirs] = File.join(engine, 'html5')
     task.examples_path.unshift 'test/examples/asciidoc-html'
   end
 end

--- a/test/tasks/generate.rake
+++ b/test/tasks/generate.rake
@@ -18,7 +18,9 @@ namespace :generate do
 
   EOS
   task :html5 do |task|
-    Asciidoctor::DocTest.examples_path.unshift 'test/examples/html5'
+    %w(test/examples/html5 test/examples/asciidoc-html).each do |path|
+      Asciidoctor::DocTest.examples_path.unshift path
+    end
 
     Asciidoctor::DocTest::HtmlGenerator.new(
       Asciidoctor::DocTest::AsciidocSuiteParser.new,

--- a/test/tasks/test.rake
+++ b/test/tasks/test.rake
@@ -12,10 +12,10 @@ namespace :test do
     end
   end
 
-  test_task :html5, :haml
   test_task :html5, :slim
+  test_task :html5, :haml
 
-  task :html5 => ['html5:haml', 'html5:slim']
+  task :html5 => ['html5:slim', 'html5:haml']
   task :all   => ['html5']
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,8 @@
 require 'asciidoctor-doctest'
-require 'diffy'
 require 'minitest/autorun'
 require 'minitest/rg'
 require 'tilt'
 
-%w(test/examples/html5 test/examples/asciidoc-html).each do |path|
+%w[test/examples/html5 test/examples/asciidoc-html].each do |path|
   Asciidoctor::DocTest.examples_path.unshift path
 end
-
-# Colorize diff!
-Diffy::Diff.default_format = :color

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,9 @@ require 'minitest/autorun'
 require 'minitest/rg'
 require 'tilt'
 
-Asciidoctor::DocTest.examples_path.unshift 'test/examples/html5'
+%w(test/examples/html5 test/examples/asciidoc-html).each do |path|
+  Asciidoctor::DocTest.examples_path.unshift path
+end
 
 # Colorize diff!
 Diffy::Diff.default_format = :color


### PR DESCRIPTION
I’ve refactored Slim templates for HTML5 backend in order to separate most of logic into helpers, make templates more clear, simpler and “DRY”.

This PR includes seven previous (not yet merged) PRs and also some future changes/fixes. I’ll rebase it later to make it more clear, so consider this PR just as a preview for review. The most important commit is [this](https://github.com/jirutka/asciidoctor-backends/commit/d7dce1b40b7e9479ab84253113194f2619780eb9).

I depends on changes in the upcoming Asciidoctor 1.5.2.