### PR TITLE
Fix inline_footnote – handle unresolved xref

### DIFF
--- a/haml/html5/inline_footnote.html.haml
+++ b/haml/html5/inline_footnote.html.haml
@@ -1,8 +1,11 @@
-- if @type == :xref
-  %span.footnoteref<
-    = surround '[', ']' do
-      %a.footnote(href="#_footnote_#{attr :index}" title="View footnote.")=attr :index
-- else
-  %span.footnote{:id=>(['_footnote', @id] if @id)}<
-    = surround '[', ']' do
-      %a.footnote(href="#_footnote_#{attr :index}" title="View footnote."){:id=>['_footnoteref', (attr :index)]}=attr :index
+- if (index = attr :index)
+  - if @type == :xref
+    %span.footnoteref<
+      = surround '[', ']' do
+        %a.footnote(href="#_footnote_#{index}" title="View footnote.")=index
+  - else
+    %span.footnote{:id=>(['_footnote', @id] if @id)}<
+      = surround '[', ']' do
+        %a.footnote(href="#_footnote_#{index}" title="View footnote."){:id=>['_footnoteref', index]}=index
+- elsif @type == :xref
+  %span.footnoteref.red(title="Unresolved footnote reference.")="[#{text}]"

--- a/slim/html5/inline_footnote.html.slim
+++ b/slim/html5/inline_footnote.html.slim
@@ -1,6 +1,9 @@
-- if @type == :xref
-  span.footnoteref
-    | [<a class="footnote" href="#_footnote_#{attr :index}" title="View footnote.">#{attr :index}</a>]
-- else
-  span.footnote id=("_footnote_#{@id}" if @id)
-    | [<a id="_footnoteref_#{attr :index}" class="footnote" href="#_footnote_#{attr :index}" title="View footnote.">#{attr :index}</a>]
+- if (index = attr :index)
+  - if @type == :xref
+    span.footnoteref
+      | [<a class="footnote" href="#_footnote_#{index}" title="View footnote.">#{index}</a>]
+  - else
+    span.footnote id=("_footnote_#{@id}" if @id)
+      | [<a id="_footnoteref_#{index}" class="footnote" href="#_footnote_#{index}" title="View footnote.">#{index}</a>]
+- elsif @type == :xref
+  span.footnoteref.red title="Unresolved footnote reference." [#{text}]

--- a/test/examples/html5/inline_footnote.html
+++ b/test/examples/html5/inline_footnote.html
@@ -10,3 +10,6 @@ Apocalyptic party.<span class="footnote">[<a class="footnote" href="#_footnote_1
 -->
 A bold statement.<span class="footnote" id="_footnote_disclaimer">[<a class="footnote" href="#_footnote_1" id="_footnoteref_1" title="View footnote.">1</a>]</span>
 Another outrageous statement.<span class="footnoteref">[<a class="footnote" href="#_footnote_1" title="View footnote.">1</a>]</span>
+
+<!-- .xref-unresolved -->
+A bold statement.<span class="footnoteref red" title="Unresolved footnote reference.">[foobar]</span>


### PR DESCRIPTION
To be consistent with the built-in version of the backend ([this line](https://github.com/asciidoctor/asciidoctor/blob/v1.5.1/lib/asciidoctor/converter/html5.rb#L997)).
