### PR TITLE
Update to highlightjs 8.4

### DIFF
--- a/haml/deckjs/document.html.haml
+++ b/haml/deckjs/document.html.haml
@@ -36,8 +36,8 @@
         - else
           =Asciidoctor::Stylesheets.instance.embed_pygments_stylesheet(attr 'pygments-style')
     - when 'highlightjs'
-      %link(rel='stylesheet' href="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3'}/styles/#{attr 'highlightjs-theme', 'default'}.min.css")
-      %script(src="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.3'}/highlight.min.js")
+      %link(rel='stylesheet' href="#{attr :highlightjsdir, '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4'}/styles/#{attr 'highlightjs-theme', 'default'}.min.css")
+      %script(src="#{attr :highlightjsdir, '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4'}/highlight.min.js")
       %script hljs.initHighlightingOnLoad()
     - when 'prettify'
       %link(rel='stylesheet' href="#{attr :prettifydir, 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/#{attr 'prettify-theme', 'prettify'}.min.css")

--- a/haml/html5/document.html.haml
+++ b/haml/html5/document.html.haml
@@ -39,9 +39,8 @@
         - else
           %style=Asciidoctor::Stylesheets.instance.pygments_stylesheet_data(attr 'pygments-style')
     - when 'highlightjs'
-      %link(rel='stylesheet' href="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/styles/#{attr 'highlightjs-theme', 'googlecode'}.min.css")
-      %script(src="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/highlight.min.js")
-      %script(src="#{attr :highlightjsdir, 'http://cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'}/lang/common.min.js")
+      %link(rel='stylesheet' href="#{attr :highlightjsdir, '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4'}/styles/#{attr 'highlightjs-theme', 'googlecode'}.min.css")
+      %script(src="#{attr :highlightjsdir, '//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4'}/highlight.min.js")
       %script hljs.initHighlightingOnLoad()
     - when 'prettify'
       %link(rel='stylesheet' href="#{attr :prettifydir, 'http://cdnjs.cloudflare.com/ajax/libs/prettify/r298'}/#{attr 'prettify-theme', 'prettify'}.min.css")


### PR DESCRIPTION
Common languages are now packed into `highlight.min.js`

Addresses https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/149