### PR TITLE
Use last version of Font Awesome (4.5.0)

### DIFF
--- a/erb/html5/document.html.erb
+++ b/erb/html5/document.html.erb
@@ -28,7 +28,7 @@ elsif attr? :stylesheet
 end
 if attr? :icons, 'font'
   if !(attr 'iconfont-remote', '').nil? %>
-<link rel="stylesheet" href="<%= attr 'iconfont-cdn', 'http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.min.css' %>"><%
+<link rel="stylesheet" href="<%= attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css' %>"><%
   else %>
 <link rel="stylesheet" href="<%= normalize_web_path(%(#{attr 'iconfont-name', 'font-awesome'}.css), (attr :stylesdir, '')) %>"><%
   end

--- a/haml/html5/document.html.haml
+++ b/haml/html5/document.html.haml
@@ -22,7 +22,7 @@
         %style=read_asset(normalize_system_path((attr :stylesheet), (attr :stylesdir, '')), true)
     - if attr? :icons, 'font'
       - if !(attr 'iconfont-remote', '').nil?
-        %link(rel='stylesheet'){:href=>(attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css')}
+        %link(rel='stylesheet'){:href=>(attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css')}
       - else
         %link(rel='stylesheet'){:href=>normalize_web_path("#{attr 'iconfont-name', 'font-awesome'}.css", (attr :stylesdir, ''))}
     - case attr 'source-highlighter'

--- a/slim/dzslides/document.html.slim
+++ b/slim/dzslides/document.html.slim
@@ -14,7 +14,7 @@ html lang=(attr :lang, 'en' unless attr? :nolang) class="aspect-#{attr 'dzslides
     link rel='stylesheet' href="http://fonts.googleapis.com/css?#{attr 'dzslides-fonts', 'family=Oswald'}"
     - if attr? :icons, 'font'
       - if (attr 'iconfont-remote', '')
-        link rel='stylesheet' href=(attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css')
+        link rel='stylesheet' href=(attr 'iconfont-cdn', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css')
       - else
         link rel='stylesheet' href=normalize_web_path("#{attr 'iconfont-name', 'font-awesome'}.css", (attr :stylesdir, ''))
     - if attr? 'source-highlighter'

--- a/slim/html5/helpers.rb
+++ b/slim/html5/helpers.rb
@@ -15,7 +15,7 @@ end
 module Slim::Helpers
 
   # URIs of external assets.
-  FONT_AWESOME_URI     = '//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.1.0/css/font-awesome.min.css'
+  FONT_AWESOME_URI     = '//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.5.0/css/font-awesome.min.css'
   HIGHLIGHTJS_BASE_URI = '//cdnjs.cloudflare.com/ajax/libs/highlight.js/7.4'
   MATHJAX_JS_URI       = '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML'
   PRETTIFY_BASE_URI    = '//cdnjs.cloudflare.com/ajax/libs/prettify/r298'


### PR DESCRIPTION
All the references to Font Awesome are now pointing to the 4.5.0 version (https://fortawesome.github.io/Font-Awesome/get-started/).

The URL in `erb/html5/document.html.erb` is now in https (instead of http). If there's a specific reason to be in http, sorry, let me know and I'll do the change.