### PR TITLE
added explicit namespace of DEFAULT_TOCLEVELS

### DIFF
--- a/slim/html5/block_outline.html.slim
+++ b/slim/html5/block_outline.html.slim
@@ -1,5 +1,5 @@
 - unless sections.empty?
-  - toclevels ||= (document.attr 'toclevels', DEFAULT_TOCLEVELS).to_i
+  - toclevels ||= (document.attr 'toclevels', ::Slim::Helpers::DEFAULT_TOCLEVELS).to_i
   - slevel = section_level sections.first
   ul class="sectlevel#{slevel}"
     - sections.each do |sec|


### PR DESCRIPTION
html5 backend can't build toc, beacuse `DEFAULT_TOCLEVELS` can't be found.
```
~/git/nopeslide/asciidoctor-backends/slim/html5/block_outline.html.slim:2:in `__tilt_47186724551020': uninitialized constant Asciidoctor::Document::DEFAULT_TOCLEVELS (NameError)
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/converter/template.rb:109:in `convert'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/converter/composite.rb:28:in `convert'
	from ~/git/nopeslide/asciidoctor-backends/slim/html5/document.html.slim:54:in `__tilt_47186724551020'
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `call'
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:170:in `evaluate'
	from ~/.gem/ruby/2.6.0/gems/tilt-2.0.10/lib/tilt/template.rb:109:in `render'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/converter/template.rb:107:in `convert'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/converter/composite.rb:28:in `convert'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/document.rb:951:in `convert'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/convert.rb:118:in `convert'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/convert.rb:183:in `block in convert_file'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/convert.rb:183:in `open'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/convert.rb:183:in `convert_file'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/cli/invoker.rb:128:in `block in invoke!'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/cli/invoker.rb:111:in `each'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/lib/asciidoctor/cli/invoker.rb:111:in `invoke!'
	from ~/.gem/ruby/2.6.0/gems/asciidoctor-2.0.11.dev/bin/asciidoctor:15:in `<main>'
```