### PR TITLE
Fix Haml HTML Listing Template

### DIFF
--- a/haml/html5/block_listing.html.haml
+++ b/haml/html5/block_listing.html.haml
@@ -26,6 +26,8 @@
         - nowrap = false
       - pre_class << 'nowrap' if nowrap
       %pre{:class=>pre_class, :lang=>pre_lang}
-        %code{:class=>code_class, 'data-lang'=>code_lang}=content
+        %code{:class=>code_class, 'data-lang'=>code_lang}
+          :preserve
+            #{content}
     - else
       %pre{:class=>('nowrap' if nowrap)}=content


### PR DESCRIPTION
Add the `:preserve` filter to `block_listing.html.haml` to ensure that first-line indentation is always preserved.

The original template was removing indentation of the first line in code blocks beginning with an indented line, when used in conjunction with some syntax highlighters (e.g. with Highlight, using the tree processor extension `highlight-treeprocessor.rb` from asciidoctor-extensions-lab).

The added `:preserve` filter, in conjunction with `#{content}`, now ensures that indentation is always preserved.

For more info on the problem, see:

- tajmone/hugo-book#15
- alan-if/alan-docs#70

