### PR TITLE
Fix EditorConfig Conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION

Add `.gitattributes` file and set `* text=auto eol=lf`, to conform with the rules in `.editorconfig`.

This solves conflicts with the EditorConfig settings for Windows users, because `.editorconfig` is enforcing `LF` EOL on all text files, whereas without adequate `.gitattributes` settings, Git would default to `native` EOL for all text files, under MS Windows, resulting in the editor/IDE enforcing `LF`, and Git rejecting the commits if the user has set Git to `core.eol = native` and `core.safecrlf = true` (recommended settings).

In other words, without this `.gitattributes` fix, Windows users with proper Git settings and an editor supporting EditorConfig won't be able to commit changes to the repository.